### PR TITLE
Panasonic PTZ improvements

### DIFF
--- a/src/devices/__tests__/panasonicPTZ.spec.ts
+++ b/src/devices/__tests__/panasonicPTZ.spec.ts
@@ -56,9 +56,21 @@ describe('Panasonic PTZ', () => {
 			deviceId: 'myPtz',
 			mappingType: MappingPanasonicPtzType.PRESET_SPEED
 		}
+		let myChannelMapping2: MappingPanasonicPtz = {
+			device: DeviceType.PANASONIC_PTZ,
+			deviceId: 'myPtz',
+			mappingType: MappingPanasonicPtzType.ZOOM
+		}
+		let myChannelMapping3: MappingPanasonicPtz = {
+			device: DeviceType.PANASONIC_PTZ,
+			deviceId: 'myPtz',
+			mappingType: MappingPanasonicPtzType.ZOOM_SPEED
+		}
 		let myChannelMapping: Mappings = {
 			'ptz_k1': myChannelMapping0,
-			'ptz_k1_s': myChannelMapping1
+			'ptz_k1_s': myChannelMapping1,
+			'ptz_k1_z': myChannelMapping2,
+			'ptz_k1_zs': myChannelMapping3
 		}
 
 		let myConductor = new Conductor({
@@ -138,7 +150,7 @@ describe('Panasonic PTZ', () => {
 				id: 'obj2_s',
 				trigger: {
 					type: TriggerType.TIME_ABSOLUTE,
-					value: mockTime.now + 1000 // 1 seconds in the past
+					value: mockTime.now + 1000 // 1 seconds in the future
 				},
 				duration: 500,
 				LLayer: 'ptz_k1_s',
@@ -158,6 +170,32 @@ describe('Panasonic PTZ', () => {
 				content: {
 					type: TimelineContentTypePanasonicPtz.PRESET,
 					preset: 1
+				}
+			},
+			{
+				id: 'obj4',
+				trigger: {
+					type: TriggerType.TIME_ABSOLUTE,
+					value: mockTime.now + 6000 // 6 seconds in the future
+				},
+				duration: 2000,
+				LLayer: 'ptz_k1_z',
+				content: {
+					type: TimelineContentTypePanasonicPtz.ZOOM,
+					zoom: 0
+				}
+			},
+			{
+				id: 'obj5',
+				trigger: {
+					type: TriggerType.TIME_ABSOLUTE,
+					value: mockTime.now + 6000 // 6 seconds in the future
+				},
+				duration: 2000,
+				LLayer: 'ptz_k1_zs',
+				content: {
+					type: TimelineContentTypePanasonicPtz.ZOOM_SPEED,
+					zoomSpeed: 1
 				}
 			}
 		]
@@ -224,5 +262,31 @@ describe('Panasonic PTZ', () => {
 
 		expect(commandReceiver0).toHaveBeenCalledTimes(6)
 		// no new commands should be sent, nothing is sent on object end
+
+		mockTime.advanceTimeTo(16500)
+
+		expect(commandReceiver0).toHaveBeenCalledTimes(8)
+		expect(commandReceiver0.mock.calls[6][1]).toMatchObject(
+			{
+				type: TimelineContentTypePanasonicPtz.ZOOM_SPEED,
+				speed: 1
+			}
+		)
+		expect(commandReceiver0.mock.calls[7][1]).toMatchObject(
+			{
+				type: TimelineContentTypePanasonicPtz.ZOOM,
+				zoom: 0
+			}
+		)
+		mockTime.advanceTimeTo(18500)
+
+		// The end of Zoom Speed object should reset zoom speed to 0
+		expect(commandReceiver0).toHaveBeenCalledTimes(9)
+		expect(commandReceiver0.mock.calls[8][1]).toMatchObject(
+			{
+				type: TimelineContentTypePanasonicPtz.ZOOM_SPEED,
+				speed: 0
+			}
+		)
 	})
 })

--- a/src/devices/panasonicPTZ.ts
+++ b/src/devices/panasonicPTZ.ts
@@ -81,6 +81,9 @@ export class PanasonicPtzDevice extends DeviceWithState<TimelineState> {
 				this.emit('error', 'PanasonicPtzHttpInterface disconnected', msg)
 				this._setConnected(false)
 			})
+			this._device.on('debug', (...args) => {
+				this.emit('debug', 'Panasonic PTZ', ...args)
+			})
 		} else {
 			this._device = undefined
 		}
@@ -184,7 +187,7 @@ export class PanasonicPtzDevice extends DeviceWithState<TimelineState> {
 		return {
 			preset: undefined,
 			speed: undefined,
-			zoomSpeed: undefined,
+			zoomSpeed: 0,
 			zoom: undefined
 		}
 	}

--- a/src/devices/panasonicPTZAPI.ts
+++ b/src/devices/panasonicPTZAPI.ts
@@ -56,9 +56,12 @@ export class PanasonicPtzCamera extends EventEmitter {
 			return
 		}
 
+		const queryUrl = this._url + '?' + querystring.stringify({ 'cmd': qItem.command, 'res': '1' })
+		this.emit('debug', 'Command sent', queryUrl)
+
 		qItem.executing = true
 		request.get(
-			this._url + '?' + querystring.stringify({ 'cmd': qItem.command, 'res': '1' }),
+			queryUrl,
 			{},
 			(error, response) => {
 				if (error) {
@@ -128,6 +131,9 @@ export class PanasonicPtzHttpInterface extends EventEmitter {
 		this._device.on('error', (err) => {
 			this.emit('error', err)
 		})
+		this._device.on('debug', (...args) => {
+			this.emit('debug', ...args)
+		})
 	}
 
 	private static _isError (response: string) {
@@ -153,14 +159,12 @@ export class PanasonicPtzHttpInterface extends EventEmitter {
 		return new Promise((resolve, reject) => {
 			device.sendCommand(PanasonicHttpCommands.PRESET_NUMBER_QUERY).then((response) => {
 				if (PanasonicPtzHttpInterface._isError(response)) {
-					this.emit('error', response)
-					reject(response)
+					reject(`Device returned an error: ${response}`)
 				} else if (response.startsWith(PanasonicHttpResponse.PRESET_NUMBER_TPL)) {
 					const preset = Number.parseInt(response.substr(PanasonicHttpResponse.PRESET_NUMBER_TPL.length), 10)
 					resolve(preset)
 				} else {
-					this.emit('error', response)
-					reject(response)
+					reject(`Unknown response: ${response}`)
 				}
 			}).catch((error) => {
 				this.emit('disconnected', error)
@@ -184,14 +188,12 @@ export class PanasonicPtzHttpInterface extends EventEmitter {
 		return new Promise((resolve, reject) => {
 			device.sendCommand(sprintf(PanasonicHttpCommands.PRESET_NUMBER_CONTROL_TPL, preset)).then((response) => {
 				if (PanasonicPtzHttpInterface._isError(response)) {
-					this.emit('error', response)
-					reject(response)
+					reject(`Device returned an error: ${response}`)
 				} else if (response.startsWith(PanasonicHttpResponse.PRESET_NUMBER_TPL)) {
 					const preset = Number.parseInt(response.substr(PanasonicHttpResponse.PRESET_NUMBER_TPL.length), 10)
 					resolve(preset)
 				} else {
-					this.emit('error', response)
-					reject(response)
+					reject(`Unknown response: ${response}`)
 				}
 			}).catch((error) => {
 				this.emit('disconnected', error)
@@ -211,14 +213,12 @@ export class PanasonicPtzHttpInterface extends EventEmitter {
 		return new Promise((resolve, reject) => {
 			device.sendCommand(PanasonicHttpCommands.PRESET_SPEED_QUERY).then((response) => {
 				if (PanasonicPtzHttpInterface._isError(response)) {
-					this.emit('error', response)
-					reject(response)
+					reject(`Device returned an error: ${response}`)
 				} else if (response.startsWith(PanasonicHttpResponse.PRESET_SPEED_TPL)) {
 					const speed = Number.parseInt(response.substr(PanasonicHttpResponse.PRESET_SPEED_TPL.length), 10)
 					resolve(speed)
 				} else {
-					this.emit('error', response)
-					reject(response)
+					reject(`Unknown response: ${response}`)
 				}
 			}).catch((error) => {
 				this.emit('disconnected', error)
@@ -242,14 +242,12 @@ export class PanasonicPtzHttpInterface extends EventEmitter {
 		return new Promise((resolve, reject) => {
 			device.sendCommand(sprintf(PanasonicHttpCommands.PRESET_SPEED_CONTROL_TPL, speed)).then((response) => {
 				if (PanasonicPtzHttpInterface._isError(response)) {
-					this.emit('error', response)
-					reject(response)
+					reject(`Device returned an error: ${response}`)
 				} else if (response.startsWith(PanasonicHttpResponse.PRESET_SPEED_TPL)) {
 					const speed = Number.parseInt(response.substr(PanasonicHttpResponse.PRESET_SPEED_TPL.length), 10)
 					resolve(speed)
 				} else {
-					this.emit('error', response)
-					reject(response)
+					reject(`Unknown response: ${response}`)
 				}
 			}).catch((error) => {
 				this.emit('disconnected', error)
@@ -269,14 +267,12 @@ export class PanasonicPtzHttpInterface extends EventEmitter {
 		return new Promise((resolve, reject) => {
 			device.sendCommand(PanasonicHttpCommands.ZOOM_SPEED_QUERY).then((response) => {
 				if (PanasonicPtzHttpInterface._isError(response)) {
-					this.emit('error', response)
-					reject(response)
+					reject(`Device returned an error: ${response}`)
 				} else if (response.startsWith(PanasonicHttpResponse.ZOOM_SPEED_TPL)) {
 					const speed = Number.parseInt(response.substr(PanasonicHttpResponse.ZOOM_SPEED_TPL.length), 10)
 					resolve(speed)
 				} else {
-					this.emit('error', response)
-					reject(response)
+					reject(`Unknown response: ${response}`)
 				}
 			}).catch((error) => {
 				this.emit('disconnected', error)
@@ -300,14 +296,12 @@ export class PanasonicPtzHttpInterface extends EventEmitter {
 		return new Promise((resolve, reject) => {
 			device.sendCommand(sprintf(PanasonicHttpCommands.ZOOM_SPEED_CONTROL_TPL, speed)).then((response) => {
 				if (PanasonicPtzHttpInterface._isError(response)) {
-					this.emit('error', response)
-					reject(response)
+					reject(`Device returned an error: ${response}`)
 				} else if (response.startsWith(PanasonicHttpResponse.ZOOM_SPEED_TPL)) {
 					const speed = Number.parseInt(response.substr(PanasonicHttpResponse.ZOOM_SPEED_TPL.length), 10)
 					resolve(speed)
 				} else {
-					this.emit('error', response)
-					reject(response)
+					reject(`Unknown response: ${response}`)
 				}
 			}).catch((error) => {
 				this.emit('disconnected', error)
@@ -327,14 +321,12 @@ export class PanasonicPtzHttpInterface extends EventEmitter {
 		return new Promise((resolve, reject) => {
 			device.sendCommand(PanasonicHttpCommands.ZOOM_QUERY).then((response) => {
 				if (PanasonicPtzHttpInterface._isError(response)) {
-					this.emit('error', response)
-					reject(response)
+					reject(`Device returned an error: ${response}`)
 				} else if (response.startsWith(PanasonicHttpResponse.ZOOM_TPL)) {
 					const zoom = Number.parseInt(response.substr(PanasonicHttpResponse.ZOOM_TPL.length), 16)
 					resolve(zoom)
 				} else {
-					this.emit('error', response)
-					reject(response)
+					reject(`Unknown response: ${response}`)
 				}
 			}).catch((error) => {
 				this.emit('disconnected', error)
@@ -358,14 +350,12 @@ export class PanasonicPtzHttpInterface extends EventEmitter {
 		return new Promise((resolve, reject) => {
 			device.sendCommand(sprintf(PanasonicHttpCommands.ZOOM_CONTROL_TPL, level)).then((response) => {
 				if (PanasonicPtzHttpInterface._isError(response)) {
-					this.emit('error', response)
-					reject(response)
+					reject(`Device returned an error: ${response}`)
 				} else if (response.startsWith(PanasonicHttpResponse.ZOOM_CONTROL_TPL)) {
 					const level = Number.parseInt(response.substr(PanasonicHttpResponse.ZOOM_CONTROL_TPL.length), 16)
 					resolve(level)
 				} else {
-					this.emit('error', response)
-					reject(response)
+					reject(`Unknown response: ${response}`)
 				}
 			}).catch((error) => {
 				this.emit('disconnected', error)
@@ -384,8 +374,7 @@ export class PanasonicPtzHttpInterface extends EventEmitter {
 		return new Promise((resolve, reject) => {
 			device.sendCommand(PanasonicHttpCommands.POWER_MODE_QUERY).then((response) => {
 				if (PanasonicPtzHttpInterface._isError(response)) {
-					this.emit('error', response)
-					reject(response)
+					reject(`Device returned an error: ${response}`)
 				} else if (response === PanasonicHttpResponse.POWER_MODE_ON) {
 					resolve(true)
 				} else if (response === PanasonicHttpResponse.POWER_MODE_STBY) {
@@ -393,8 +382,7 @@ export class PanasonicPtzHttpInterface extends EventEmitter {
 				} else if (response === PanasonicHttpResponse.POWER_MODE_TURNING_ON) {
 					resolve('turningOn')
 				} else {
-					this.emit('error', response)
-					reject(response)
+					reject(`Unknown response: ${response}`)
 				}
 			}).catch((error) => {
 				this.emit('disconnected', error)

--- a/src/devices/panasonicPTZAPI.ts
+++ b/src/devices/panasonicPTZAPI.ts
@@ -97,7 +97,7 @@ enum PanasonicHttpCommands {
 	PRESET_SPEED_QUERY = '#UPVS',
 	ZOOM_SPEED_CONTROL_TPL = '#Z%02i',
 	ZOOM_SPEED_QUERY = '#Z',
-	ZOOM_CONTROL_TPL = '#AXZ%03Xh',
+	ZOOM_CONTROL_TPL = '#AXZ%03X',
 	ZOOM_QUERY = '#GZ'
 }
 enum PanasonicHttpResponse {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix for an issue with formatting of the set zoom command to camera & also improves logging of the commands so that the actual URL requested is also logged.


* **What is the current behavior?** (You can also link to an open issue here)
The command is sent with the speed code sent as "FFFh", and should be sent as "FFF" (the Panasonic manual isn't very clear on what formatting should be used). Also, the logging from the Panasonic PTZ device is very sparse.