### PR TITLE
feat(atem): Simplify lookahead handling logic to only support WHEN_CLEAR and the updated RETAIN mode

### DIFF
--- a/src/devices/atem.ts
+++ b/src/devices/atem.ts
@@ -9,7 +9,6 @@ import {
 import {
 	DeviceType,
 	DeviceOptions,
-	TimelineResolvedObjectExtended,
 	TimelineContentTypeAtem,
 	MappingAtem,
 	MappingAtemType,
@@ -195,56 +194,36 @@ export class AtemDevice extends DeviceWithState<DeviceState> {
 			.sort((a,b) => a.layerName.localeCompare(b.layerName))
 
 		_.each(sortedLayers, ({ tlObject, layerName }) => {
-			const tlObjectExt = tlObject as TimelineResolvedObjectExtended
 			const content = tlObject.resolved || tlObject.content
 			let mapping = this.mapping[layerName] as MappingAtem // tslint:disable-line
-			if (!mapping && tlObjectExt.originalLLayer) {
-				mapping = this.mapping[tlObjectExt.originalLLayer] as MappingAtem // tslint:disable-line
-			}
 
 			if (mapping) {
 				if (mapping.index !== undefined && mapping.index >= 0) { // index must be 0 or higher
-
 					switch (mapping.mappingType) {
 						case MappingAtemType.MixEffect:
-							if (tlObjectExt.isBackground) {
-								break
-							}
 							if (content.type === TimelineContentTypeAtem.ME) {
 								let me = deviceState.video.ME[mapping.index]
 								if (me) deepExtend(me, content.attributes)
 							}
 							break
 						case MappingAtemType.DownStreamKeyer:
-							if (tlObjectExt.isBackground) {
-								break
-							}
 							if (content.type === TimelineContentTypeAtem.DSK) {
 								let dsk = deviceState.video.downstreamKeyers[mapping.index]
 								if (dsk) deepExtend(dsk, content.attributes)
 							}
 							break
 						case MappingAtemType.SuperSourceBox:
-							if (tlObjectExt.isBackground && (!tlObjectExt.originalLLayer || tlObjectExt.originalLLayer && state.LLayers[tlObjectExt.originalLLayer])) {
-								break
-							}
 							if (content.type === TimelineContentTypeAtem.SSRC) {
 								let ssrc = deviceState.video.superSourceBoxes
 								if (ssrc) deepExtend(ssrc, content.attributes.boxes)
 							}
 							break
 						case MappingAtemType.Auxilliary:
-							if (tlObjectExt.isBackground) {
-								break
-							}
 							if (content.type === TimelineContentTypeAtem.AUX) {
 								deviceState.video.auxilliaries[mapping.index] = content.attributes.input
 							}
 							break
 						case MappingAtemType.MediaPlayer:
-							if (tlObjectExt.isBackground) {
-								break
-							}
 							if (content.type === TimelineContentTypeAtem.MEDIAPLAYER) {
 								let ms = deviceState.media.players[mapping.index]
 								if (ms) deepExtend(ms, content.attributes)
@@ -252,12 +231,11 @@ export class AtemDevice extends DeviceWithState<DeviceState> {
 							break
 					}
 				}
+
 				if (mapping.mappingType === MappingAtemType.SuperSourceProperties) {
-					if (!(tlObjectExt.isBackground && (!tlObjectExt.originalLLayer || tlObjectExt.originalLLayer && state.LLayers[tlObjectExt.originalLLayer]))) {
-						if (content.type === TimelineContentTypeAtem.SSRCPROPS) {
-							let ssrc = deviceState.video.superSourceProperties
-							if (ssrc) deepExtend(ssrc, content.attributes)
-						}
+					if (content.type === TimelineContentTypeAtem.SSRCPROPS) {
+						let ssrc = deviceState.video.superSourceProperties
+						if (ssrc) deepExtend(ssrc, content.attributes)
 					}
 				}
 			}


### PR DESCRIPTION
This changes the atem device to not use the originalLLayer property, and instead rely on core to insert lookahead onto the same layer. As the doesn't have a background that it can use to preload, doing it via a separate layer makes no sense (unlike with ccg)

Partner of https://github.com/nrkno/tv-automation-server-core/commit/f0df41ce2b81c8e4b2017ab7e2fef8ba523990fb