### PR TITLE
fix(tsr): Restrict the next resolve time to inside the current window

### DIFF
--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -516,7 +516,7 @@ export class Conductor extends EventEmitter {
 				// this.emit('debug', 'timeUntilNextResolve', timeUntilNextResolve)
 
 				// resolve at nextEvent.time next time:
-				this._nextResolveTime = nextEvent.time
+				this._nextResolveTime = Math.min(tlState.time + LOOKAHEADTIME, nextEvent.time)
 
 			} else {
 				// there's nothing ahead in the timeline


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This restricts the next resolve time to inside the current window, to ensure we don't miss something that the timeline excluded.

* **What is the current behavior?** (You can also link to an open issue here)

If we have an active group at 1000-10000, and another group at 9000. After a resolve at 2000, the next resolve will be at 10000, so the start of the new group will be done late. 

* **Other information**:
