### PR TITLE
feat: Combine casparcg VIDEO and AUDIO types into single MEDIA type

### DIFF
--- a/examples/playVideoInCaspar.ts
+++ b/examples/playVideoInCaspar.ts
@@ -50,7 +50,7 @@ let a = async function () {
 		duration: 60 * 1000,
 		LLayer: 'layer0',
 		content: {
-			type: TimelineContentTypeCasparCg.VIDEO,
+			type: TimelineContentTypeCasparCg.MEDIA,
 			attributes: {
 				file: 'AMB',
 				loop: true

--- a/examples/testChangeTimelineQuickly.ts
+++ b/examples/testChangeTimelineQuickly.ts
@@ -52,7 +52,7 @@ let a = async function () {
 				duration: 60 * 1000,
 				LLayer: 'layer0',
 				content: {
-					type: TimelineContentTypeCasparCg.VIDEO,
+					type: TimelineContentTypeCasparCg.MEDIA,
 					attributes: {
 						file: 'AMB',
 						loop: true
@@ -72,7 +72,7 @@ let a = async function () {
 					duration: 60 * 1000,
 					LLayer: 'layer0',
 					content: {
-						type: TimelineContentTypeCasparCg.VIDEO,
+						type: TimelineContentTypeCasparCg.MEDIA,
 						attributes: {
 							file: 'CG1080i50',
 							loop: true
@@ -88,7 +88,7 @@ let a = async function () {
 					duration: 60 * 1000,
 					LLayer: 'layer0',
 					content: {
-						type: TimelineContentTypeCasparCg.VIDEO,
+						type: TimelineContentTypeCasparCg.MEDIA,
 						attributes: {
 							file: 'AMB',
 							loop: true

--- a/src/devices/__tests__/casparcg.spec.ts
+++ b/src/devices/__tests__/casparcg.spec.ts
@@ -73,7 +73,7 @@ describe('CasparCG', () => {
 				duration: 2000,
 				LLayer: 'myLayer0',
 				content: {
-					type: TimelineContentTypeCasparCg.VIDEO,
+					type: TimelineContentTypeCasparCg.MEDIA,
 					attributes: {
 						file: 'AMB',
 						loop: true
@@ -555,7 +555,7 @@ describe('CasparCG', () => {
 				duration: 2000,
 				LLayer: 'myLayer0',
 				content: {
-					type: TimelineContentTypeCasparCg.VIDEO, // more to be implemented later!
+					type: TimelineContentTypeCasparCg.MEDIA, // more to be implemented later!
 					attributes: {
 						file: 'AMB'
 					},
@@ -656,7 +656,7 @@ describe('CasparCG', () => {
 				duration: 12000, // 12s
 				LLayer: 'myLayer0',
 				content: {
-					type: TimelineContentTypeCasparCg.VIDEO, // more to be implemented later!
+					type: TimelineContentTypeCasparCg.MEDIA, // more to be implemented later!
 					attributes: {
 						file: 'AMB',
 						loop: true
@@ -791,7 +791,7 @@ describe('CasparCG', () => {
 				isBackground: true,
 				LLayer: 'myLayer0',
 				content: {
-					type: TimelineContentTypeCasparCg.VIDEO,
+					type: TimelineContentTypeCasparCg.MEDIA,
 					attributes: {
 						file: 'AMB',
 						loop: true
@@ -807,7 +807,7 @@ describe('CasparCG', () => {
 				duration: 2000,
 				LLayer: 'myLayer0',
 				content: {
-					type: TimelineContentTypeCasparCg.VIDEO,
+					type: TimelineContentTypeCasparCg.MEDIA,
 					attributes: {
 						file: 'AMB',
 						loop: true
@@ -887,7 +887,7 @@ describe('CasparCG', () => {
 				duration: 1200,
 				LLayer: 'myLayer0',
 				content: {
-					type: TimelineContentTypeCasparCg.VIDEO,
+					type: TimelineContentTypeCasparCg.MEDIA,
 					attributes: {
 						file: 'AMB',
 						loop: true
@@ -903,7 +903,7 @@ describe('CasparCG', () => {
 				duration: 2000,
 				LLayer: 'myLayer0',
 				content: {
-					type: TimelineContentTypeCasparCg.VIDEO,
+					type: TimelineContentTypeCasparCg.MEDIA,
 					attributes: {
 						file: 'AMB',
 						loop: true

--- a/src/devices/casparCG.ts
+++ b/src/devices/casparCG.ts
@@ -20,7 +20,7 @@ import {
 	TimelineContentTypeCasparCg,
 	MappingCasparCG,
 	CasparCGOptions,
-	TimelineObjCCGVideo,
+	TimelineObjCCGMedia,
 	TimelineObjCCGHTMLPage,
 	TimelineObjCCGRoute,
 	TimelineObjCCGInput,
@@ -256,7 +256,7 @@ export class CasparCGDevice extends DeviceWithState<TimelineState> {
 					layer.content.type === TimelineContentTypeCasparCg.AUDIO || // to be deprecated & replaced by MEDIA
 					layer.content.type === TimelineContentTypeCasparCg.MEDIA
 				) {
-					const mediaObj = layer as TimelineObjCCGVideo & TimelineResolvedObjectExtended
+					const mediaObj = layer as TimelineObjCCGMedia & TimelineResolvedObjectExtended
 
 					let l: StateNS.IMediaLayer = {
 						layerNo: mapping.layer,

--- a/src/types/src/casparcg.ts
+++ b/src/types/src/casparcg.ts
@@ -27,8 +27,7 @@ export enum TimelineContentTypeCasparCg { //  CasparCG-state
 	RECORD = 'record'
 }
 
-export type TimelineObjCCGAny = TimelineObjCCGAudio
-	| TimelineObjCCGVideo
+export type TimelineObjCCGAny = TimelineObjCCGMedia
 	| TimelineObjCCGInput
 	| TimelineObjCCGHTMLPage
 	| TimelineObjCCGRecord
@@ -55,21 +54,9 @@ export interface TimelineObjCCGProducerContentBase {
 	mixer?: Mixer
 }
 
-export interface TimelineObjCCGAudio extends TimelineObject {
+export interface TimelineObjCCGMedia extends TimelineObject {
 	content: {
-		type: TimelineContentTypeCasparCg.AUDIO
-		attributes: {
-			file: string
-			loop?: boolean
-			audioFilter?: string
-			channelLayout?: string
-		}
-	} & TimelineObjCCGProducerContentBase
-}
-
-export interface TimelineObjCCGVideo extends TimelineObject {
-	content: {
-		type: TimelineContentTypeCasparCg.VIDEO
+		type: TimelineContentTypeCasparCg.MEDIA
 		attributes: {
 			file: string
 			loop?: boolean


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Replaces TimelineObjCCGVideo and TimelineObjCCGAudio with a single TimelineObjCCGMedia type.
Any objects of the old type will still work currently. As a second phase later on we can remove the TimelineContentTypeCasparCg enum values for them too.
