### PR TITLE
Feature/http send cordering

### DIFF
--- a/src/devices/__tests__/httpsend.spec.ts
+++ b/src/devices/__tests__/httpsend.spec.ts
@@ -190,11 +190,8 @@ describe('HTTP-Send', () => {
 
 		// Expecting to see the ordering below:
 		expect(commandReceiver0).toHaveBeenCalledTimes(3)
-		expect(commandReceiver0.mock.calls[0][1]).toMatchObject( { url: 'http://superfly.tv/1' })
-		expect(commandReceiver0.mock.calls[1][1]).toMatchObject( { url: 'http://superfly.tv/3' })
-		expect(commandReceiver0.mock.calls[2][1]).toMatchObject( { url: 'http://superfly.tv/2' })
-
-		await mockTime.advanceTimeToTicks(16000)
-		expect(commandReceiver0).toHaveBeenCalledTimes(1)
+		expect(commandReceiver0).toBeCalledWith(expect.anything(), expect.objectContaining({ url: 'http://superfly.tv/1' }), expect.anything())
+		expect(commandReceiver0).toBeCalledWith(expect.anything(), expect.objectContaining({ url: 'http://superfly.tv/3' }), expect.anything())
+		expect(commandReceiver0).toBeCalledWith(expect.anything(), expect.objectContaining({ url: 'http://superfly.tv/2' }), expect.anything())
 	})
 })

--- a/src/devices/__tests__/httpsend.spec.ts
+++ b/src/devices/__tests__/httpsend.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '../../types/src'
 import { MockTime } from '../../__tests__/mockTime.spec'
 import { ThreadedClass } from 'threadedclass'
+import { TimelineObjHTTPRequest, TimelineContentTypeHttp } from '../../types/src/http'
 
 // let nowActual = Date.now()
 describe('HTTP-Send', () => {
@@ -90,6 +91,109 @@ describe('HTTP-Send', () => {
 			}
 		)
 		expect(commandReceiver0.mock.calls[0][2]).toMatch(/added/) // context
+		await mockTime.advanceTimeToTicks(16000)
+		expect(commandReceiver0).toHaveBeenCalledTimes(1)
+	})
+	test('POST message, ordering of commands', async () => {
+		let commandReceiver0 = jest.fn(() => {
+			return Promise.resolve()
+		})
+		let myLayerMapping0: MappingHTTPSend = {
+			device: DeviceType.HTTPSEND,
+			deviceId: 'myHTTP'
+		}
+		let myLayerMapping1: MappingHTTPSend = {
+			device: DeviceType.HTTPSEND,
+			deviceId: 'myHTTP'
+		}
+		let myLayerMapping2: MappingHTTPSend = {
+			device: DeviceType.HTTPSEND,
+			deviceId: 'myHTTP'
+		}
+		let myLayerMapping: Mappings = {
+			'myLayer0': myLayerMapping0,
+			'myLayer1': myLayerMapping0,
+			'myLayer2': myLayerMapping0
+		}
+
+		let myConductor = new Conductor({
+			initializeAsClear: true,
+			getCurrentTime: mockTime.getCurrentTime
+		})
+		await myConductor.init()
+		await myConductor.addDevice('myHTTP', {
+			type: DeviceType.HTTPSEND,
+			options: {
+				commandReceiver: commandReceiver0
+			}
+		})
+		myConductor.mapping = myLayerMapping
+		await mockTime.advanceTimeToTicks(10100)
+
+		let device = myConductor.getDevice('myHTTP') as ThreadedClass<HttpSendDevice>
+
+		// Check that no commands has been scheduled:
+		expect(await device.queue).toHaveLength(0)
+
+		let timeline: Array<TimelineObjHTTPRequest> = [
+			{
+				id: 'obj0',
+				trigger: {
+					type: TriggerType.TIME_ABSOLUTE,
+					value: mockTime.now + 1000 // in 1 second
+				},
+				duration: 2000,
+				LLayer: 'myLayer0',
+				content: {
+					type: 'POST' as TimelineContentTypeHttp,
+					url: 'http://superfly.tv/1',
+					params: {},
+					temporalPriority: 1
+				}
+			},
+			{
+				id: 'obj1',
+				trigger: {
+					type: TriggerType.TIME_ABSOLUTE,
+					value: mockTime.now + 1000 // in 1 second
+				},
+				duration: 2000,
+				LLayer: 'myLayer1',
+				content: {
+					type: 'POST' as TimelineContentTypeHttp,
+					url: 'http://superfly.tv/2',
+					params: {},
+					temporalPriority: 3
+				}
+			},
+			{
+				id: 'obj2',
+				trigger: {
+					type: TriggerType.TIME_ABSOLUTE,
+					value: mockTime.now + 1000 // in 1 second
+				},
+				duration: 2000,
+				LLayer: 'myLayer2',
+				content: {
+					type: 'POST' as TimelineContentTypeHttp,
+					url: 'http://superfly.tv/3',
+					params: {},
+					temporalPriority: 2
+				}
+			}
+		]
+		myConductor.timeline = timeline
+
+		await mockTime.advanceTimeToTicks(10990)
+		expect(commandReceiver0).toHaveBeenCalledTimes(0)
+		await mockTime.advanceTimeToTicks(11100)
+
+		// Expecting to see the ordering below:
+		expect(commandReceiver0).toHaveBeenCalledTimes(3)
+		expect(commandReceiver0.mock.calls[0][1]).toMatchObject( { url: 'http://superfly.tv/1' })
+		expect(commandReceiver0.mock.calls[1][1]).toMatchObject( { url: 'http://superfly.tv/3' })
+		expect(commandReceiver0.mock.calls[2][1]).toMatchObject( { url: 'http://superfly.tv/2' })
+
 		await mockTime.advanceTimeToTicks(16000)
 		expect(commandReceiver0).toHaveBeenCalledTimes(1)
 	})

--- a/src/devices/httpSend.ts
+++ b/src/devices/httpSend.ts
@@ -182,8 +182,11 @@ export class HttpSendDevice extends DeviceWithState<TimelineState> {
 				})
 			}
 		})
-
-		return commands.sort((a, b) => a.layer.localeCompare(b.layer))
+		return commands
+		.sort((a, b) => a.layer.localeCompare(b.layer))
+		.sort((a, b) => {
+			return (a.content.temporalPriority || 0) - (b.content.temporalPriority || 0)
+		})
 	}
 	private _defaultCommandReceiver (time: number, cmd: HttpSendCommandContent, context: CommandContext): Promise<any> {
 		time = time

--- a/src/types/src/http.ts
+++ b/src/types/src/http.ts
@@ -9,6 +9,7 @@ export interface HttpSendCommandContent {
 	type: TimelineContentTypeHttp
 	url: string
 	params: {[key: string]: number | string | any}
+	temporalPriority?: number // default: 0
 }
 export interface HttpSendOptions {
 	makeReadyCommands?: HttpSendCommandContent[]


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
No temporalOrdering of httpCommands


* **What is the new behavior (if this is a feature change)?**
Ability to add `temporalPriority` to order commands.


* **Other information**:
