### PR TITLE
fix: Some callbacks not being sent

### DIFF
--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -667,7 +667,7 @@ export class Conductor extends EventEmitter {
 			_.each(tlState.GLayers, (o: TimelineResolvedObject) => {
 				try {
 					if (o.content.callBack || o.content.callBackStopped) {
-						let callBackId = (
+						const callBackId = (
 							o.id +
 							o.content.callBack +
 							o.content.callBackStopped +
@@ -681,8 +681,10 @@ export class Conductor extends EventEmitter {
 							callBackData: o.content.callBackData
 						}
 						if (o.content.callBack && o.resolved.startTime) {
+							// Check if it will have been cleared from the doOnTime queue
+							const hasBeenSent = !!o.resolved.startTime && o.resolved.startTime < tlState.time
 							this._doOnTime.queue(o.resolved.startTime, () => {
-								if (!sentCallbacksOld[callBackId]) {
+								if (!hasBeenSent || !sentCallbacksOld[callBackId]) {
 									// Object has started playing
 									this._queueCallback({
 										type: 'start',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes some callbacks not being sent

* **What is the current behavior?** (You can also link to an open issue here)

Just before this `_.each` is a `this._doOnTime.clearQueueNowAndAfter(tlState.time)`.
If any of the callbacks get removed by that, then their `sentCallbacksOld[callbackId]` will still report a value, causing them to never be sent. 

This can happen when there are multiple state changes close to each other (I assume), so that the callbacks from the first have not been sent by the time the second is being processed.


* **What is the new behavior (if this is a feature change)?**
If the callback will have been removed by the call to `clearQueueNowAndAfter` then ignore `sentCallbacksOld`


* **Other information**:

More common with multithreaded resolving. Likely due to the state being processed more on time than before (where it was often done late)