### PR TITLE
Fix/quantel load port

### DIFF
--- a/src/devices/__tests__/quantelGateway.spec.ts
+++ b/src/devices/__tests__/quantelGateway.spec.ts
@@ -147,7 +147,8 @@ describe('QuantelGateway', () => {
 
 		const response = await quantel.loadFragmentsOntoPort(portId, fragmentInfo.fragments)
 		expect(response).toMatchObject({
-			portID: 'my_port'
+			portName: 'my_port',
+			fragmentCount: 4
 		})
 
 		expect(onError).toHaveBeenCalledTimes(0)

--- a/src/devices/__tests__/quantelGatewayMock.ts
+++ b/src/devices/__tests__/quantelGatewayMock.ts
@@ -426,7 +426,7 @@ function handleRequest (quantelServer: QuantelServerMockOptions, triggerFcn: Fun
 				'post /:zoneID/server/:serverID/port/:portID/fragments?offset=:offset': () => {
 					return { __reroute: true }
 				},
-				'post /:zoneID/server/:serverID/port/:portID/fragments': (params): Q.PortStatus | ErrorResponse => {
+				'post /:zoneID/server/:serverID/port/:portID/fragments': (params): Q.PortLoadStatus | ErrorResponse => {
 					if (params.portID === 'my_port') {
 
 						if (!_.isArray(bodyData)) throw new Error('Bad body data')
@@ -441,20 +441,13 @@ function handleRequest (quantelServer: QuantelServerMockOptions, triggerFcn: Fun
 						quantelServer[params.portID].endOfData = endOfData
 
 						return {
-							type: 'PortStatus',
+							type: 'PortLoadStatus',
 							serverID: params.serverID,
-							portName: 'fred',
-							refTime: '14:47:31:00',
-							portTime: '10:00:15:03',
-							portID: params.portID,
-							speed: 1,
+							portName: 'my_port',
 							offset: 0,
 							status: 'unknown',
-							endOfData: quantelServer[params.portID].endOfData,
-							framesUnused: 0,
-							channels: [ 1 ],
-							outputTime: '00:00:00:00'
-						}
+							fragmentCount: 4
+						} as Q.PortLoadStatus
 					}
 					return {
 						status: 404,

--- a/src/devices/__tests__/quantelGatewayMock.ts
+++ b/src/devices/__tests__/quantelGatewayMock.ts
@@ -224,6 +224,7 @@ function handleRequest (quantelServer: QuantelServerMockOptions, triggerFcn: Fun
 						{
 							type: 'ClipDataSummary',
 							ClipID: 2,
+							ClipGUID: '0b124a741fa84c3eb7a707d13cc1f5aa',
 							CloneID: 2,
 							Completed: '2019-06-12T11:18:37.000Z',
 							Created: '2019-06-12T11:18:37.000Z',
@@ -236,6 +237,7 @@ function handleRequest (quantelServer: QuantelServerMockOptions, triggerFcn: Fun
 						{
 							type: 'ClipDataSummary',
 							ClipID: 1337,
+							ClipGUID: 'abcdef872832832a2b932c97d9b2eb9',
 							CloneID: 1337,
 							Completed: '2019-06-12T11:18:37.000Z',
 							Created: '2019-06-12T11:18:37.000Z',

--- a/src/devices/quantel.ts
+++ b/src/devices/quantel.ts
@@ -547,7 +547,7 @@ class QuantelManager {
 			portInPoint = portStatus.endOfData || 0
 			const newPortStatus = await this._quantel.loadFragmentsOntoPort(cmd.portId, fragmentsInfo.fragments, portInPoint)
 			if (!newPortStatus) throw new Error(`Port ${cmd.portId} not found after loading fragments`)
-			portOutPoint = newPortStatus.endOfData - 1
+			portOutPoint = portInPoint + fragmentsInfo.fragments.reduce((x, y) => x > y.finish ? x : y.finish, 0) - 1 // newPortStatus.endOfData - 1
 
 			// Store a reference to the beginning of the fragments:
 			trackedPort.loadedFragments[clipId] = {

--- a/src/devices/quantelGateway.ts
+++ b/src/devices/quantelGateway.ts
@@ -174,7 +174,7 @@ export class QuantelGateway extends EventEmitter {
 		}
 	}
 	/** Load specified fragments onto a port */
-	public async loadFragmentsOntoPort (portId: string, fragments: Q.ServerFragmentTypes[], offset?: number): Promise<Q.PortStatus> {
+	public async loadFragmentsOntoPort (portId: string, fragments: Q.ServerFragmentTypes[], offset?: number): Promise<Q.PortLoadStatus> {
 		return this.sendServer('post', `port/${portId}/fragments`, {
 			offset: offset
 		}, fragments)

--- a/src/devices/quantelGateway.ts
+++ b/src/devices/quantelGateway.ts
@@ -429,12 +429,14 @@ export namespace Q {
 	}
 
 	export interface ClipPropertyList {
+		// Use property 'limit' of type number to set the maximum number of values to return
 		[ name: string ]: string
 	}
 
 	export interface ClipDataSummary {
 		type: 'ClipDataSummary' | 'ClipData'
 		ClipID: number
+		ClipGUID: string
 		CloneID: number | null
 		Completed: DateString | null
 		Created: DateString, // ISO-formatted date
@@ -471,7 +473,6 @@ export namespace Q {
 		Division: string
 		AudioFormats: string
 		VideoFormats: string
-		ClipGUID: string
 		Protection: string
 		VDCPID: string
 		PublishCompleted: DateString | null, // ISO-formatted date
@@ -483,12 +484,20 @@ export namespace Q {
 		start: number
 		finish: number
 	}
+
 	export type ServerFragmentTypes =
 		VideoFragment |
 		AudioFragment |
 		AUXFragment |
-		CCFragment |
+		FlagsFragment |
 		TimecodeFragment |
+		AspectFragment |
+		CropFragment |
+		PanZoomFragment |
+		SpeedFragment |
+		MultiCamFragment |
+		CCFragment |
+		NoteFragment |
 		EffectFragment
 
 	interface PositionData extends ServerFragment {
@@ -512,15 +521,9 @@ export namespace Q {
 		type: 'AUXFragment'
 	}
 
-	export interface CCFragment extends ServerFragment {
-		type: 'CCFragment'
-		ccID: string
-		ccType: number
-		effectID: number
-	}
-	export interface EffectFragment extends ServerFragment {
-		type: 'EffectFragment'
-		effectID: number
+	export interface FlagsFragment extends ServerFragment {
+		type: 'FlagsFragment'
+		flags: number
 	}
 
 	export interface TimecodeFragment extends ServerFragment {
@@ -528,7 +531,59 @@ export namespace Q {
 		userBits: number
 	}
 
-	// TODO extend with the different types
+	export interface AspectFragment extends ServerFragment {
+		type: 'AspectFragment'
+		width: number
+		height: number
+	}
+
+	export interface CropFragment extends ServerFragment {
+		type: 'CropFragment'
+		x: number
+		y: number
+		width: number
+		height: number
+	}
+
+	export interface PanZoomFragment extends ServerFragment {
+		type: 'PanZoomFragment'
+		x: number
+		y: number
+		hZoom: number
+		vZoon: number
+	}
+
+	export interface SpeedFragment extends ServerFragment {
+		type: 'SpeedFragment'
+		speed: number
+		profile: number
+	}
+
+	export interface MultiCamFragment extends ServerFragment {
+		type: 'MultiCamFragment'
+		stream: number
+	}
+
+	export interface CCFragment extends ServerFragment {
+		type: 'CCFragment'
+		ccID: string
+		ccType: number
+		effectID: number
+	}
+
+	export interface NoteFragment extends ServerFragment {
+		type: 'NoteFragment'
+		noteID: number
+		aux: number
+		mask: number
+		note: string | null
+	}
+
+	export interface EffectFragment extends ServerFragment {
+		type: 'EffectFragment'
+		effectID: number
+	}
+
 	export interface ServerFragments extends ClipRef {
 		type: 'ServerFragments'
 		fragments: ServerFragmentTypes[]
@@ -588,8 +643,10 @@ export namespace Q {
 
 	export interface ConnectionDetails {
 		type: string
-		isaIOR: string | null
+		isaIOR: string
 		href: string
+		refs: string[]
+		robin: number
 	}
 
 	export interface CloneRequest extends ClipRef {
@@ -605,5 +662,50 @@ export namespace Q {
 	export interface WipeResult extends WipeInfo {
 		type: 'WipeResult'
 		wiped: boolean
+	}
+
+	export interface FormatRef {
+		formatNumber: number
+	}
+
+	export interface FormatInfo extends FormatRef {
+		type: 'FormatInfo'
+		essenceType: 'VideoFragment' | 'AudioFragment' | 'AUXFragment' | 'FlagsFragment' |
+			'TimecodeFragment' | 'AspectFragment' | 'CropFragment' | 'PanZoomFragment' |
+			'MultiCamFragment' | 'CCFragment' | 'NoteFragment' | 'EffectFragment' | 'Unknown',
+		frameRate: number
+		height: number
+		width: number
+		samples: number
+		compressionFamily: number
+		protonsPerAtom: number
+		framesPerAtom: number
+		quark: number
+		formatName: string
+		layoutName: string
+		compressionName: string
+	}
+
+	export interface CloneInfo {
+		zoneID?: number // Source zone ID, omit for local zone
+		clipID: number // Source clip ID
+		poolID: number // Destination pool ID
+		priority?: number // Priority, between 0 (low) and 15 (high) - default is 8 (standard)
+		history?: boolean // Should an interzone clone link to historical provinance - default is true
+	}
+
+	export interface CloneResult extends CloneInfo {
+		type: 'CloneResult'
+		copyID: number
+		copyCreated: boolean
+	}
+
+	export interface CopyProgress extends ClipRef {
+		type: 'CopyProgress'
+		totalProtons: number
+		protonsLeft: number
+		secsLeft: number
+		priority: number
+		ticketed: boolean
 	}
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix to `loadFragmentsOntoPort` and calculation of `portOutPoint`. Also corrected a few other differences that have crept in between the quantel gateway types and the mirror quantel device types.

* **What is the current behavior?** (You can also link to an open issue here)

The return type of the `loadFragmentsOntoPort` method in the QuantelDevice in TSR was incorrectly assumed to be `PortStatus` instead of `LoadPortStatus`. Subsequent code was then assuming that the `endOfData` property could be used to calculate `portOutPoint`. 

A few other types were out of sync, although do not appear to be affecting the behavior of the quantel device.

* **What is the new behavior (if this is a feature change)?**

* Corrected type signature of method. 
* Changed the way `portOutPoint` is calculated to be based on the provided fragments and requested offset.
* Fixed a few other type signatures that have diverged or have been more recently added.

* **Other information**:

TSR tests pass without modification. Quantel device tests have been amended to reflect the change.
