### PR TITLE
WIP: Caspar AB playback

### DIFF
--- a/src/devices/casparCG.ts
+++ b/src/devices/casparCG.ts
@@ -457,7 +457,10 @@ export class CasparCGDevice extends DeviceWithState<TimelineState> {
 
 				if (!layerExt.isLookahead) { // foreground layer
 					const prev = channel.layers[mapping.layer] || {}
-					channel.layers[mapping.layer] = _.extend(stateLayer, _.pick(prev, 'nextUp'))
+					channel.layers[mapping.layer] = {
+						...stateLayer,
+						nextUp: prev.nextUp
+					}
 				} else { // background layer
 					let s = stateLayer as StateNS.NextUp
 					s.auto = false
@@ -478,6 +481,20 @@ export class CasparCGDevice extends DeviceWithState<TimelineState> {
 					}
 				}
 			}
+		})
+
+		_.each(caspar.channels, channel => {
+			_.each(channel.layers, (layer, i) => {
+				if (layer.content === StateNS.LayerContentType.NOTHING && layer.nextUp) {
+					// If nextUp is defined, and not foreground, then promote nextUp to be a paused foreground
+					// TODO - this needs to be driven by an option on the mapping/object
+					channel.layers[i] = {
+						...layer.nextUp,
+						playing: false, // Paused (LOAD)
+						playTime: null // Freeze at start
+					}
+				}
+			})
 		})
 
 		return caspar


### PR DESCRIPTION
This works well enough to develop caspar based AB playback in blueprints, but has some major limitations blocking real usage.

When the layer is clear allow doing a LOAD of the media instead of LOADBG, so that the first frame is visible to the user.

### TODO
- [x] Control behaviour from option
- [x] When `LOAD` fails, previous clip is still playing (need to do a `LOAD empty` first?)
- [x] Be able to do a `LOAD` without parameters to promote background clip to foreground (Needs support in ccg first)
- [x] Same clip back to back on a layer doesn't reload (due to `playing: false, startTime: null` which are both needed to pause on the first frame)
- [ ] Caspar support notOnAir property