### PR TITLE
Fix: typings library

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,13 +53,12 @@
     "installclean": "yarn unlink:all & yarn cleancache && yarn --check-files",
     "buildclean": "yarn installclean && yarn build",
     "build": "trash dist && yarn build:main",
-    "buildtest": "yarn build && jest",
     "build:main": "tsc -p tsconfig.json",
     "lint": "tslint --project tsconfig.jest.json --config tslint.json",
     "unitci": "jest --maxWorkers 2",
     "unit": "jest",
     "testci": "yarn test --maxWorkers 2",
-    "test": "yarn lint && yarn build && yarn unit",
+    "test": "yarn lint && yarn buildall && yarn unit",
     "test:integration": "yarn lint && jest --config=jest-integration.config.js",
     "watch": "jest --watch",
     "cov": "jest --coverage; opn coverage/lcov-report/index.html",
@@ -78,8 +77,9 @@
     "license-validate": "node-license-validator -p -d --allow-licenses MIT BSD BSD-2-Clause BSD-3-Clause ISC Apache Unlicense WTFPL --allow-packages cycle",
     "types-build": "cd src/types && trash dist && yarn build:main && cd ../..",
     "types-install": "cd src/types && yarn install && cd ../..",
-    "types-test": "cd src/types && yarn lint && yarn unitci && cd ../..",
-    "types-ci": "cd src/types && yarn lint && yarn unitci && cd ../.."
+    "types-test": "cd src/types && yarn test && cd ../..",
+    "types-ci": "cd src/types && yarn testci && cd ../..",
+    "buildall": "yarn build && yarn types-build"
   },
   "scripts-info": {
     "info": "Display information about the scripts",

--- a/src/__tests__/library.spec.ts
+++ b/src/__tests__/library.spec.ts
@@ -1,5 +1,5 @@
 // These imports are pointed to what external libraries will import
-import { Conductor, DeviceOptions, DeviceType } from '../../dist/'
+import { Conductor, DeviceOptions, DeviceType, CasparCGDevice } from '../../dist/'
 import {
 	DeviceType as Types_DeviceType,
 	TSRTimeline,
@@ -13,6 +13,7 @@ describe('Usage of library', () => {
 
 	test('main library', () => {
 
+		expect(CasparCGDevice).toBeTruthy()
 		expect(Conductor).toBeTruthy()
 
 		// Expect this type to exist:

--- a/src/__tests__/library.spec.ts
+++ b/src/__tests__/library.spec.ts
@@ -1,0 +1,47 @@
+// These imports are pointed to what external libraries will import
+import { Conductor, DeviceOptions, DeviceType } from '../../dist/'
+import {
+	DeviceType as Types_DeviceType,
+	TSRTimeline,
+	TimelineObjEmpty
+} from '../types/dist'
+
+describe('Usage of library', () => {
+	// These tests test that the library can be imported and used by the library consumers.
+
+	// Note that the commands 'yarn build' and 'yarn types-build' must have been run for these tests to pass
+
+	test('main library', () => {
+
+		expect(Conductor).toBeTruthy()
+
+		// Expect this type to exist:
+		const o: DeviceOptions = {
+			type: DeviceType.ABSTRACT
+		}
+		expect(o.type).toEqual(0)
+
+	})
+	test('types', () => {
+		expect(Types_DeviceType.ATEM).toEqual(2)
+
+		expect(Types_DeviceType).toEqual(DeviceType)
+
+		// Expect these types to work:
+		const obj: TimelineObjEmpty = {
+			id: 'myId',
+			enable: {
+				start: 0,
+				duration: 42
+			},
+			layer: 'myLayer',
+			content: {
+				deviceType: Types_DeviceType.ABSTRACT,
+				type: 'empty'
+			},
+			classes: []
+		}
+		const tl: TSRTimeline = [obj]
+		expect(tl[0].content.deviceType).toEqual(0)
+	})
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,5 @@
 
 export * from './conductor'
-
-export {
-	Mappings,
-	Mapping,
-	MappingAbstract,
-	DeviceType,
-	DeviceOptions
-} from './types/src/'
-
-// let myConductor = new Conductor();
 export { CasparCGDevice } from './devices/casparCG'
+
+export * from './types/src'

--- a/src/types/package.json
+++ b/src/types/package.json
@@ -48,6 +48,8 @@
 		"info": "npm-scripts-info",
 		"installclean": "yarn unlink:all & yarn cleancache && yarn --check-files",
 		"buildclean": "yarn installclean && yarn build",
+		"test": "yarn lint && yarn build && yarn unit",
+		"testci": "yarn lint && yarn build && yarn unitci",
 		"unitci": "jest --maxWorkers 2",
 		"unit": "jest",
 		"build": "trash dist && yarn build:main",

--- a/src/types/src/__tests__/library.spec.ts
+++ b/src/types/src/__tests__/library.spec.ts
@@ -1,0 +1,32 @@
+// These imports are pointed to what external libraries will import
+import {
+	DeviceType as Types_DeviceType,
+	TSRTimeline,
+	TimelineObjEmpty
+} from '../../dist'
+
+describe('Usage of library', () => {
+	// These tests test that the library can be imported and used by the library consumers.
+
+	// Note that the command 'yarn types-build' must have been run for these tests to pass
+	test('types', () => {
+		expect(Types_DeviceType.ATEM).toEqual(2)
+
+		// Expect these types to work:
+		const obj: TimelineObjEmpty = {
+			id: 'myId',
+			enable: {
+				start: 0,
+				duration: 42
+			},
+			layer: 'myLayer',
+			content: {
+				deviceType: Types_DeviceType.ABSTRACT,
+				type: 'empty'
+			},
+			classes: []
+		}
+		const tl: TSRTimeline = [obj]
+		expect(tl[0].content.deviceType).toEqual(0)
+	})
+})

--- a/src/types/src/__tests__/osc.spec.ts
+++ b/src/types/src/__tests__/osc.spec.ts
@@ -1,0 +1,59 @@
+import { OSCEasingType } from '..'
+import { Easing } from '../../../easings'
+
+describe('OSC', () => {
+	test('OSC Easing type', () => {
+
+		// Make sure OSCEasingType type reflects the original Easing class
+
+		const checkType = (typeVar: OSCEasingType) => {
+
+			const orgVar: keyof typeof Easing = typeVar
+
+			const typeVar2: OSCEasingType = orgVar
+
+			return typeVar2
+		}
+
+		checkType('Linear')
+
+		type OrgEasing = keyof typeof Easing
+
+		// Make sure the typings work
+		const orgVarLinear: OrgEasing			= 'Linear'
+		const orgVarQuadratic: OrgEasing		= 'Quadratic'
+		const orgVarCubic: OrgEasing			= 'Cubic'
+		const orgVarQuartic: OrgEasing			= 'Quartic'
+		const orgVarQuintic: OrgEasing			= 'Quintic'
+		const orgVarSinusoidal: OrgEasing		= 'Sinusoidal'
+		const orgVarExponential: OrgEasing		= 'Exponential'
+		const orgVarCircular: OrgEasing			= 'Circular'
+		const orgVarElastic: OrgEasing			= 'Elastic'
+		const orgVarBack: OrgEasing				= 'Back'
+		const orgVarBounce: OrgEasing			= 'Bounce'
+
+		const typeVarLinear: OSCEasingType			= orgVarLinear
+		const typeVarQuadratic: OSCEasingType		= orgVarQuadratic
+		const typeVarCubic: OSCEasingType			= orgVarCubic
+		const typeVarQuartic: OSCEasingType			= orgVarQuartic
+		const typeVarQuintic: OSCEasingType			= orgVarQuintic
+		const typeVarSinusoidal: OSCEasingType		= orgVarSinusoidal
+		const typeVarExponential: OSCEasingType		= orgVarExponential
+		const typeVarCircular: OSCEasingType		= orgVarCircular
+		const typeVarElastic: OSCEasingType			= orgVarElastic
+		const typeVarBack: OSCEasingType			= orgVarBack
+		const typeVarBounce: OSCEasingType			= orgVarBounce
+
+		expect(typeVarLinear).toBeTruthy()
+		expect(typeVarQuadratic).toBeTruthy()
+		expect(typeVarCubic).toBeTruthy()
+		expect(typeVarQuartic).toBeTruthy()
+		expect(typeVarQuintic).toBeTruthy()
+		expect(typeVarSinusoidal).toBeTruthy()
+		expect(typeVarExponential).toBeTruthy()
+		expect(typeVarCircular).toBeTruthy()
+		expect(typeVarElastic).toBeTruthy()
+		expect(typeVarBack).toBeTruthy()
+		expect(typeVarBounce).toBeTruthy()
+	})
+})

--- a/src/types/src/osc.ts
+++ b/src/types/src/osc.ts
@@ -1,6 +1,8 @@
 import { Mapping } from './mapping'
 import { TSRTimelineObjBase, DeviceType } from '.'
-import { Easing } from '../../easings'
+
+// Note: This type is a loose referral to (a copy of) keyof typeof Easing in '../../easings', so that Easing structure won't be included in the types package
+export type OSCEasingType = 'Linear' | 'Quadratic' | 'Cubic' | 'Quartic' | 'Quintic' | 'Sinusoidal' | 'Exponential' | 'Circular' | 'Elastic' | 'Back' | 'Bounce'
 
 export interface OSCOptions {
 	host: string
@@ -42,7 +44,7 @@ export interface OSCMessageCommandContent {
 	values: SomeOSCValue[]
 	transition?: {
 		duration: number
-		type: keyof typeof Easing
+		type: OSCEasingType
 		direction: 'In' | 'Out' | 'InOut' | 'None'
 	}
 	from?: SomeOSCValue[]


### PR DESCRIPTION
There was an unexpected error in the previous publication of TSR causing the types-library to not be importable by library consumers.

This PR fixes the issue and adds unit tests to make sure the library stays importable.