### PR TITLE
Develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "request": "^2.88.0",
     "sprintf-js": "^1.1.2",
     "superfly-timeline": "^7.2.1",
-    "threadedclass": "^0.6.3",
+    "threadedclass": "^0.6.4",
     "underscore": "^1.9.1",
     "underscore-deep-extend": "^1.1.5",
     "ws": "^7.1.1"

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -453,16 +453,18 @@ export class Conductor extends EventEmitter {
 	 * Safely remove a device
 	 * @param deviceId The id of the device to be removed
 	 */
-	public removeDevice (deviceId: string): Promise<void> {
+	public async removeDevice (deviceId: string): Promise<void> {
 		let device = this.devices[deviceId]
-
 		if (device) {
-			return device.device.terminate()
-			.then((res) => {
-				if (res) {
-					delete this.devices[deviceId]
-				}
-			})
+			try {
+				await device.device.terminate()
+			} catch (e) {
+				// An error while terminating is probably not that important, since we'll kill the instance anyway
+				this.emit('warning', 'Error when terminating device', e)
+			}
+			await device.terminate()
+
+			delete this.devices[deviceId]
 		} else {
 			return Promise.reject('No device found')
 		}

--- a/src/devices/abstract.ts
+++ b/src/devices/abstract.ts
@@ -44,8 +44,7 @@ export class AbstractDevice extends DeviceWithState<TimelineState> {
 		this._doOnTime = new DoOnTime(() => {
 			return this.getCurrentTime()
 		}, SendMode.BURST, this._deviceOptions)
-		this._doOnTime.on('error', e => this.emit('error', 'Abstract.doOnTime', e))
-		this._doOnTime.on('slowCommand', msg => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this.handleDoOnTime(this._doOnTime, 'Abstract')
 	}
 
 	/**

--- a/src/devices/atem.ts
+++ b/src/devices/atem.ts
@@ -85,8 +85,7 @@ export class AtemDevice extends DeviceWithState<DeviceState> {
 		this._doOnTime = new DoOnTime(() => {
 			return this.getCurrentTime()
 		}, SendMode.BURST, this._deviceOptions)
-		this._doOnTime.on('error', e => this.emit('error', 'Atem.doOnTime', e))
-		this._doOnTime.on('slowCommand', msg => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this.handleDoOnTime(this._doOnTime, 'Atem')
 	}
 
 	/**

--- a/src/devices/casparCG.ts
+++ b/src/devices/casparCG.ts
@@ -88,8 +88,7 @@ export class CasparCGDevice extends DeviceWithState<TimelineState> {
 		this._doOnTime = new DoOnTime(() => {
 			return this.getCurrentTime()
 		}, SendMode.BURST, this._deviceOptions)
-		this._doOnTime.on('error', e => this.emit('error', 'CasparCG.doOnTime', e))
-		this._doOnTime.on('slowCommand', msg => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this.handleDoOnTime(this._doOnTime, 'CasparCG')
 	}
 
 	/**

--- a/src/devices/device.ts
+++ b/src/devices/device.ts
@@ -6,6 +6,7 @@ import {
 	DeviceOptions
 } from '../types/src'
 import { EventEmitter } from 'events'
+import { CommandReport, DoOnTime } from '../doOnTime'
 /*
 	This is a base class for all the Device wrappers.
 	The Device wrappers will
@@ -193,6 +194,7 @@ export abstract class Device extends EventEmitter {
 	emit (event: 'connectionChanged',	status: DeviceStatus): boolean
 	emit (event: 'resetResolver'): boolean
 	emit (event: 'slowCommand',			commandInfo: string): boolean
+	emit (event: 'commandReport',		commandReport: CommandReport): boolean
 	emit (event: 'commandError',		error: Error, context: CommandWithContext): boolean
 	emit (event: string, ...args: any[]): boolean {
 		return super.emit(event, ...args)
@@ -284,5 +286,10 @@ export abstract class DeviceWithState<T> extends Device {
 		_.each(_.keys(this._states), (time: string) => {
 			delete this._states[time]
 		})
+	}
+	protected handleDoOnTime (doOnTime: DoOnTime, deviceType: string) {
+		doOnTime.on('error', e => this.emit('error', `${deviceType}.doOnTime`, e))
+		doOnTime.on('slowCommand', msg => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		doOnTime.on('commandReport', commandReport => this.emit('commandReport', commandReport))
 	}
 }

--- a/src/devices/deviceContainer.ts
+++ b/src/devices/deviceContainer.ts
@@ -53,7 +53,6 @@ export class DeviceContainer {
 	}
 
 	public async terminate () {
-		console.error('Deviceconainter.terminate')
 		await ThreadedClassManager.destroy(this._device)
 	}
 

--- a/src/devices/deviceContainer.ts
+++ b/src/devices/deviceContainer.ts
@@ -1,7 +1,8 @@
 import {
 	ThreadedClass,
 	threadedClass,
-	ThreadedClassConfig
+	ThreadedClassConfig,
+	ThreadedClassManager
 } from 'threadedclass'
 import { DeviceClassOptions, Device } from './device'
 import { DeviceOptions, DeviceType } from '../types/src'

--- a/src/devices/deviceContainer.ts
+++ b/src/devices/deviceContainer.ts
@@ -52,6 +52,11 @@ export class DeviceContainer {
 		this._deviceName = await this.device.deviceName
 	}
 
+	public async terminate() {
+		console.error('Deviceconainter.terminate')
+		await ThreadedClassManager.destroy(this._device)
+	}
+
 	public get device (): ThreadedClass<Device> 				{ return this._device }
 	public get deviceId (): string 								{ return this._deviceId }
 	public get deviceType (): DeviceType 						{ return this._deviceType }

--- a/src/devices/deviceContainer.ts
+++ b/src/devices/deviceContainer.ts
@@ -52,7 +52,7 @@ export class DeviceContainer {
 		this._deviceName = await this.device.deviceName
 	}
 
-	public async terminate() {
+	public async terminate () {
 		console.error('Deviceconainter.terminate')
 		await ThreadedClassManager.destroy(this._device)
 	}

--- a/src/devices/httpSend.ts
+++ b/src/devices/httpSend.ts
@@ -51,8 +51,7 @@ export class HttpSendDevice extends DeviceWithState<TimelineState> {
 		this._doOnTime = new DoOnTime(() => {
 			return this.getCurrentTime()
 		}, SendMode.IN_ORDER, this._deviceOptions)
-		this._doOnTime.on('error', e => this.emit('error', 'HTTPSend.doOnTime', e))
-		this._doOnTime.on('slowCommand', msg => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this.handleDoOnTime(this._doOnTime, 'HTTPSend')
 	}
 	init (options: HttpSendOptions): Promise<boolean> {
 		this._makeReadyCommands = options.makeReadyCommands || []

--- a/src/devices/hyperdeck.ts
+++ b/src/devices/hyperdeck.ts
@@ -83,8 +83,7 @@ export class HyperdeckDevice extends DeviceWithState<DeviceState> {
 		this._doOnTime = new DoOnTime(() => {
 			return this.getCurrentTime()
 		}, SendMode.BURST, this._deviceOptions)
-		this._doOnTime.on('error', e => this.emit('error', 'Hyperdeck.doOnTime', e))
-		this._doOnTime.on('slowCommand', msg => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this.handleDoOnTime(this._doOnTime, 'Hyperdeck')
 	}
 
 	/**

--- a/src/devices/lawo.ts
+++ b/src/devices/lawo.ts
@@ -114,8 +114,7 @@ export class LawoDevice extends DeviceWithState<TimelineState> {
 		this._doOnTime = new DoOnTime(() => {
 			return this.getCurrentTime()
 		}, SendMode.BURST, this._deviceOptions)
-		this._doOnTime.on('error', e => this.emit('error', 'Lawo.doOnTime', e))
-		this._doOnTime.on('slowCommand', msg => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this.handleDoOnTime(this._doOnTime, 'Lawo')
 
 		this._lawo = new DeviceTree(host, port)
 		this._lawo.on('error', (e) => {

--- a/src/devices/osc.ts
+++ b/src/devices/osc.ts
@@ -68,8 +68,7 @@ export class OSCMessageDevice extends DeviceWithState<TimelineState> {
 		this._doOnTime = new DoOnTime(() => {
 			return this.getCurrentTime()
 		}, SendMode.BURST, this._deviceOptions)
-		this._doOnTime.on('error', e => this.emit('error', 'OSC.doOnTime', e))
-		this._doOnTime.on('slowCommand', msg => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this.handleDoOnTime(this._doOnTime, 'OSC')
 	}
 	init (options: OSCOptions): Promise<boolean> {
 		this._oscClient = new osc.UDPPort({

--- a/src/devices/panasonicPTZ.ts
+++ b/src/devices/panasonicPTZ.ts
@@ -88,8 +88,7 @@ export class PanasonicPtzDevice extends DeviceWithState<TimelineState> {
 		this._doOnTime = new DoOnTime(() => {
 			return this.getCurrentTime()
 		}, SendMode.BURST, this._deviceOptions)
-		this._doOnTime.on('error', e => this.emit('error', 'Pana PTZ.doOnTime', e))
-		this._doOnTime.on('slowCommand', msg => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this.handleDoOnTime(this._doOnTime, 'PanasonicPTZ')
 
 		if (deviceOptions.options && deviceOptions.options.host) {
 			// set up connection class

--- a/src/devices/pharos.ts
+++ b/src/devices/pharos.ts
@@ -62,8 +62,7 @@ export class PharosDevice extends DeviceWithState<TimelineState> {
 		this._doOnTime = new DoOnTime(() => {
 			return this.getCurrentTime()
 		}, SendMode.BURST, this._deviceOptions)
-		this._doOnTime.on('error', e => this.emit('error', 'Pharos.doOnTime', e))
-		this._doOnTime.on('slowCommand', msg => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this.handleDoOnTime(this._doOnTime, 'Pharos')
 
 		this._pharos = new Pharos()
 

--- a/src/devices/quantel.ts
+++ b/src/devices/quantel.ts
@@ -79,14 +79,12 @@ export class QuantelDevice extends DeviceWithState<QuantelState> {
 		this._doOnTime = new DoOnTime(() => {
 			return this.getCurrentTime()
 		}, SendMode.IN_ORDER, this._deviceOptions)
-		this._doOnTime.on('error', e => this.emit('error', 'Quantel.doOnTime', e))
-		this._doOnTime.on('slowCommand', msg => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this.handleDoOnTime(this._doOnTime, 'Quantel')
 
 		this._doOnTimeBurst = new DoOnTime(() => {
 			return this.getCurrentTime()
 		}, SendMode.BURST, this._deviceOptions)
-		this._doOnTimeBurst.on('error', e => this.emit('error', 'Quantel.doOnTimeBurst', e))
-		this._doOnTimeBurst.on('slowCommand', msg => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this.handleDoOnTime(this._doOnTimeBurst, 'Quantel.burst')
 	}
 
 	async init (connectionOptions: QuantelOptions): Promise<boolean> {

--- a/src/devices/sisyfos.ts
+++ b/src/devices/sisyfos.ts
@@ -58,8 +58,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> {
 		this._doOnTime = new DoOnTime(() => {
 			return this.getCurrentTime()
 		}, SendMode.BURST, this._deviceOptions)
-		this._doOnTime.on('error', e => this.emit('error', 'OSC.doOnTime', e))
-		this._doOnTime.on('slowCommand', msg => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this.handleDoOnTime(this._doOnTime, 'Sisyfos')
 	}
 	init (options: SisfyosOptions): Promise<boolean> {
 

--- a/src/devices/tcpSend.ts
+++ b/src/devices/tcpSend.ts
@@ -59,8 +59,7 @@ export class TCPSendDevice extends DeviceWithState<TimelineState> {
 		this._doOnTime = new DoOnTime(() => {
 			return this.getCurrentTime()
 		}, SendMode.IN_ORDER, this._deviceOptions)
-		this._doOnTime.on('error', e => this.emit('error', 'HTTPSend.doOnTime', e))
-		this._doOnTime.on('slowCommand', msg => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this.handleDoOnTime(this._doOnTime, 'TCPSend')
 	}
 	init (options: TCPSendOptions): Promise<boolean> {
 		this._makeReadyCommands = options.makeReadyCommands || []

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 
 export * from './conductor'
+export * from './doOnTime'
 export { CasparCGDevice } from './devices/casparCG'
 export { HyperdeckDevice } from './devices/hyperdeck'
 

--- a/src/types/src/mapping.ts
+++ b/src/types/src/mapping.ts
@@ -19,6 +19,7 @@ export interface DeviceOptions extends SlowReportOptions {
 	type: DeviceType
 	isMultiThreaded?: boolean
 	threadUsage?: number
+	disable?: boolean
 	options?: {}
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1032,12 +1032,7 @@ caching-transform@^3.0.2:
     package-hash "^3.0.0"
     write-file-atomic "^2.4.2"
 
-callsites@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
-  integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
-
-callsites@^3.0.0:
+callsites@^3.0.0, callsites@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
@@ -5716,12 +5711,12 @@ text-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-2.0.0.tgz#43eabd1b495482fae4a2bf65e5f56c29f69220f6"
   integrity sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==
 
-threadedclass@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/threadedclass/-/threadedclass-0.6.3.tgz#8bf6cbd0522c1a557b243848a823439db0a610b9"
-  integrity sha512-thTKgVNwtozM3G8NKYEUQut5oxkSfQrft6PB79d4ZrfmjQHTkoCKsvC5G+qc8gtnz22Icewgmm7tTd0vAYDNnQ==
+threadedclass@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/threadedclass/-/threadedclass-0.6.4.tgz#674dcc987ad58f41a6a26ab2d08ca402fe12a55f"
+  integrity sha512-/AaKcZAp4TapCKXKsxIL2ezte9k2NBd+f5ZBbA2wSCDQXGq2r0CZRYwuNuQNHItSOjp3sLGiHNLi5rEE+cozZQ==
   dependencies:
-    callsites "^2.0.0"
+    callsites "^3.1.0"
     tslib "^1.9.3"
 
 throat@^4.0.0:


### PR DESCRIPTION
This PR contains several fixes:

* Quantel: cleverer jump strategy, don't jump to same place twice
* commandReport: all devices now emits commandReport events, with timing info of the commands execution
* Properly exit child processes when removing devices. It turned out that we left orphaned processes behind when removing/restarting devices..