### PR TITLE
fix: quantel: a try to get the quantel player to behave nicely when j…

### DIFF
--- a/src/devices/quantel.ts
+++ b/src/devices/quantel.ts
@@ -735,14 +735,17 @@ class QuantelManager extends EventEmitter {
 					await this._quantel.portPrepareJump(cmd.portId, jumpToOffset)
 					trackedPort.jumpOffset = jumpToOffset
 
-					// Allow the server some time to load the clip:
-					await this.wait(SOFT_JUMP_WAIT_TIME) // This is going to give the
-
 					if (alsoDoAction === 'pause') {
 						// Pause the playback:
 						await this._quantel.portStop(cmd.portId)
 						trackedPort.scheduledStop = null
 						trackedPort.playing = false
+
+						// Allow the server some time to load the clip:
+						await this.wait(SOFT_JUMP_WAIT_TIME) // This is going to give the
+					} else {
+						// Allow the server some time to load the clip:
+						await this.wait(SOFT_JUMP_WAIT_TIME) // This is going to give the
 					}
 
 					// Trigger the jump:


### PR DESCRIPTION
Fix: A try to get the quantel player to behave nicely when jumping to a new clip.
For some unknown reason, the quantel server is playing a couple of frames on the next clip, when really it should not..