### PR TITLE
fix: Quantel: set all lookahead objects as notOnAir

### DIFF
--- a/src/devices/quantel.ts
+++ b/src/devices/quantel.ts
@@ -265,7 +265,7 @@ export class QuantelDevice extends DeviceWithState<QuantelState> {
 					const clip = layer as any as TimelineObjQuantelClip
 
 					port.timelineObjId = layer.id
-					port.notOnAir = layer.content.notOnAir
+					port.notOnAir = layer.content.notOnAir || isLookahead
 					port.outTransition = layer.content.outTransition
 
 					port.clip = {


### PR DESCRIPTION
This is a fix to mark all lookaheads as notOnAir