### PR TITLE
feat: use a timeline obj to retrigger lawo commands

### DIFF
--- a/src/devices/__tests__/lawo.spec.ts
+++ b/src/devices/__tests__/lawo.spec.ts
@@ -32,8 +32,14 @@ describe('Lawo', () => {
 			mappingType: MappingLawoType.SOURCE,
 			identifier: 'BASE'
 		}
+		let myRetriggerMapping: MappingLawo = {
+			device: DeviceType.LAWO,
+			deviceId: 'myLawo',
+			mappingType: MappingLawoType.TRIGGER_VALUE
+		}
 		let myChannelMapping: Mappings = {
-			'lawo_c1_fader': myChannelMapping0
+			'lawo_c1_fader': myChannelMapping0,
+			'lawo_trigger': myRetriggerMapping
 		}
 
 		let myConductor = new Conductor({
@@ -116,16 +122,12 @@ describe('Lawo', () => {
 					start: mockTime.now + 2000, // 2 seconds in the future
 					duration: 2000
 				},
-				layer: 'lawo_c1_fader',
+				layer: 'lawo_trigger',
 				content: {
 					deviceType: DeviceType.LAWO,
-					type: TimelineContentTypeLawo.SOURCE,
+					type: TimelineContentTypeLawo.TRIGGER_VALUE,
 
-					'Fader/Motor dB Value': {
-						value: -4,
-						transitionDuration: 400,
-						triggerValue: 'asdf' // only used for trigging new command sent
-					}
+					triggerValue: 'asdf' // only used for trigging new command sent
 				}
 			}
 		]

--- a/src/types/src/lawo.ts
+++ b/src/types/src/lawo.ts
@@ -4,21 +4,23 @@ import { TSRTimelineObjBase, DeviceType } from '.'
 export interface MappingLawo extends Mapping {
 	device: DeviceType.LAWO
 	mappingType: MappingLawoType
-	identifier: string
+	identifier?: string
 	emberType?: EmberTypes
 	priority?: number
 }
 export enum MappingLawoType {
 	SOURCE = 'source',
-	FULL_PATH = 'fullpath'
+	FULL_PATH = 'fullpath',
+	TRIGGER_VALUE = 'triggerValue'
 }
 
 export enum TimelineContentTypeLawo { //  Lawo-state
 	SOURCE = 'lawosource', // a general content type, possibly to be replaced by specific ones later?
-	EMBER_PROPERTY = 'lawofullpathemberproperty'
+	EMBER_PROPERTY = 'lawofullpathemberproperty',
+	TRIGGER_VALUE = 'triggervalue'
 }
 
-export type TimelineObjLawoAny = TimelineObjLawoSource | TimelineObjLawoEmberProperty
+export type TimelineObjLawoAny = TimelineObjLawoSource | TimelineObjLawoEmberProperty | TimelineObjLawoEmberRetrigger
 export enum EmberTypes {
 	STRING = 'string',
 	INTEGER = 'integer',
@@ -41,7 +43,6 @@ export interface TimelineObjLawoSource extends TimelineObjLawoBase {
 		'Fader/Motor dB Value': {
 			value: number
 			transitionDuration?: number
-			triggerValue?: string // only used for trigging new command sent
 		}
 	}
 }
@@ -50,5 +51,12 @@ export interface TimelineObjLawoEmberProperty extends TimelineObjLawoBase {
 		deviceType: DeviceType.LAWO
 		type: TimelineContentTypeLawo.EMBER_PROPERTY
 		value: EmberValueTypes
+	}
+}
+export interface TimelineObjLawoEmberRetrigger extends TimelineObjLawoBase {
+	content: {
+		deviceType: DeviceType.LAWO
+		type: TimelineContentTypeLawo.TRIGGER_VALUE
+		triggerValue: string
 	}
 }


### PR DESCRIPTION
This PR removes the use of the triggerValue on the lawo timeline objects and instead looks for an object on the timeline with a triggerValue. This means that timings for retriggering can be more precise.

In addition, removing a triggerValue from the timeline will no longer retrigger commands as we consider retrigger to be an action and not a state.