### PR TITLE
fix(atem): audio channel tsr objects are correctly merged

### DIFF
--- a/src/devices/atem.ts
+++ b/src/devices/atem.ts
@@ -269,7 +269,7 @@ export class AtemDevice extends DeviceWithState<DeviceState> {
 								if (chan) {
 									deviceState.audio.channels[mapping.index] = {
 										...chan,
-										...atemObj.content
+										...atemObj.content.audioChannel
 									}
 								}
 							}


### PR DESCRIPTION
Previous behaviour:

Audio channels would not be controlled by TSR at all

New behaviour:
Timeline objects are merged correctly into the state objects and TSR controls the audio channels on the atem