### PR TITLE
Feature: CasparCG sting transition audio fades

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "tslint": "^5.18.0",
     "tslint-config-standard": "^8.0.1",
     "typedoc": "^0.15.0",
-    "typescript": "^3.3.3333"
+    "typescript": "3.6.x"
   },
   "keywords": [
     "broadcast",
@@ -153,8 +153,8 @@
   "dependencies": {
     "atem-connection": "1.1.0",
     "atem-state": "0.8.0",
-    "casparcg-connection": "^4.8.0",
-    "casparcg-state": "^1.9.0",
+    "casparcg-connection": "4.8.1",
+    "casparcg-state": "^1.9.1",
     "emberplus": "git+https://github.com/nrkno/tv-automation-emberplus-connection#dist200919_1",
     "fast-clone": "^1.5.13",
     "hyperdeck-connection": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -153,8 +153,8 @@
   "dependencies": {
     "atem-connection": "1.1.0",
     "atem-state": "0.8.0",
-    "casparcg-connection": "^4.7.0",
-    "casparcg-state": "^1.8.1",
+    "casparcg-connection": "^4.8.0",
+    "casparcg-state": "^1.9.0",
     "emberplus": "git+https://github.com/nrkno/tv-automation-emberplus-connection#dist200919_1",
     "fast-clone": "^1.5.13",
     "hyperdeck-connection": "^0.4.0",

--- a/src/devices/casparCG.ts
+++ b/src/devices/casparCG.ts
@@ -428,20 +428,10 @@ export class CasparCGDevice extends DeviceWithState<TimelineState> {
 							let media = stateLayer.media
 							let transitions = {} as any
 							if (baseContent.transitions.inTransition) {
-								transitions.inTransition = new StateNS.Transition(
-									baseContent.transitions.inTransition.type,
-									baseContent.transitions.inTransition.duration || baseContent.transitions.inTransition.maskFile,
-									baseContent.transitions.inTransition.easing || baseContent.transitions.inTransition.delay,
-									baseContent.transitions.inTransition.direction || baseContent.transitions.inTransition.overlayFile
-								)
+								transitions.inTransition = new StateNS.Transition(baseContent.transitions.inTransition)
 							}
 							if (baseContent.transitions.outTransition) {
-								transitions.outTransition = new StateNS.Transition(
-									baseContent.transitions.outTransition.type,
-									baseContent.transitions.outTransition.duration || baseContent.transitions.outTransition.maskFile,
-									baseContent.transitions.outTransition.easing || baseContent.transitions.outTransition.delay,
-									baseContent.transitions.outTransition.direction || baseContent.transitions.outTransition.overlayFile
-								)
+								transitions.outTransition = new StateNS.Transition(baseContent.transitions.outTransition)
 							}
 							stateLayer.media = new StateNS.TransitionObject(media, {
 								inTransition: transitions.inTransition,

--- a/src/types/src/casparcg.ts
+++ b/src/types/src/casparcg.ts
@@ -39,8 +39,8 @@ export interface TimelineStingTransition {
 	maskFile?: string
 	delay?: number
 	overlayFile?: string
-	fadeStart?: number
-	fadeDuration?: number
+	audioFadeStart?: number
+	audioFadeDuration?: number
 }
 
 export interface TimelineObjCCGProducerContentBase {

--- a/src/types/src/casparcg.ts
+++ b/src/types/src/casparcg.ts
@@ -25,14 +25,22 @@ export enum TimelineContentTypeCasparCg { //  CasparCG-state
 	RECORD = 'record'
 }
 
-export interface TimelineTransition { // TODO split into transition and sting
+export type TimelineTransition = RegularTimelineTransition | TimelineStingTransition
+
+export interface RegularTimelineTransition {
 	type: Transition
 	duration?: number,
 	easing?: Ease,
 	direction?: Direction
+}
+
+export interface TimelineStingTransition {
+	type: Transition.STING
 	maskFile?: string
 	delay?: number
 	overlayFile?: string
+	fadeStart?: number
+	fadeDuration?: number
 }
 
 export interface TimelineObjCCGProducerContentBase {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1055,10 +1055,19 @@ casparcg-connection@^4.7.0:
     xml2js "^0.4.19"
     xmlbuilder "^9.0.7"
 
-casparcg-state@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/casparcg-state/-/casparcg-state-1.8.1.tgz#845b2ef51426ef9af7888146426eb31d9d7dffa3"
-  integrity sha512-kUBd91fOznkuV38RqmVx7XMU/ZQdlchQmQeZpdrz5W7tnywHUj/oxhG+6dmlOj7VB0XXJRET6QRFwYpWWCJemw==
+casparcg-connection@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/casparcg-connection/-/casparcg-connection-4.8.0.tgz#874710e29f65f6daf48c637082391a284fe486be"
+  integrity sha512-wYfAEPQanabuyxe1PGfdqOLtHCcoEEjdlUj/fmJt9Nx9QBLCZVxy/5Wyapi9h2x/pBz+Jh611uG6Os56Ghpb5A==
+  dependencies:
+    highland "^3.0.0-beta.6"
+    xml2js "^0.4.19"
+    xmlbuilder "^9.0.7"
+
+casparcg-state@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/casparcg-state/-/casparcg-state-1.9.0.tgz#29fedf389d998f0f48e488c36a70aebe8b8f6fbf"
+  integrity sha512-PVwhhsStkppW/vqV8q3U5eYnnvCjXki8ub5l4Zvx0HnKL0kZLkrL6dVulYK3JXgftzBvJXsIGyIb/h+u0taNIA==
   dependencies:
     casparcg-connection "^4.7.0"
     fast-clone "^1.5.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1046,6 +1046,15 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+casparcg-connection@4.8.1:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/casparcg-connection/-/casparcg-connection-4.8.1.tgz#9cbb54e1575cb7757679f3e1821ecb958b64ba6a"
+  integrity sha512-r+axV6pZj/LWbkm97+SFvx/k4AWD90ug3dvyw7CxeTma1qzoAWeSBKoOrF9xWvkwXViu/vqUkWbLHsqvNl2VCA==
+  dependencies:
+    highland "^3.0.0-beta.6"
+    xml2js "^0.4.19"
+    xmlbuilder "^9.0.7"
+
 casparcg-connection@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/casparcg-connection/-/casparcg-connection-4.7.0.tgz#c2aa4b5b5a89b17bffac77f592627aca8ec3537e"
@@ -1055,19 +1064,10 @@ casparcg-connection@^4.7.0:
     xml2js "^0.4.19"
     xmlbuilder "^9.0.7"
 
-casparcg-connection@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/casparcg-connection/-/casparcg-connection-4.8.0.tgz#874710e29f65f6daf48c637082391a284fe486be"
-  integrity sha512-wYfAEPQanabuyxe1PGfdqOLtHCcoEEjdlUj/fmJt9Nx9QBLCZVxy/5Wyapi9h2x/pBz+Jh611uG6Os56Ghpb5A==
-  dependencies:
-    highland "^3.0.0-beta.6"
-    xml2js "^0.4.19"
-    xmlbuilder "^9.0.7"
-
-casparcg-state@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/casparcg-state/-/casparcg-state-1.9.0.tgz#29fedf389d998f0f48e488c36a70aebe8b8f6fbf"
-  integrity sha512-PVwhhsStkppW/vqV8q3U5eYnnvCjXki8ub5l4Zvx0HnKL0kZLkrL6dVulYK3JXgftzBvJXsIGyIb/h+u0taNIA==
+casparcg-state@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/casparcg-state/-/casparcg-state-1.9.1.tgz#09702adbb68269c57b8cb154caff92eadb1b0369"
+  integrity sha512-cwAiczngF72eyQs42OZg55OlWJ5dsEdse01yKGX14i5scfnaDW5HOnF4lt/jIO4+3tjKyhRMxcj8tnR/c9nZ1Q==
   dependencies:
     casparcg-connection "^4.7.0"
     fast-clone "^1.5.13"
@@ -5808,7 +5808,7 @@ typescript@3.5.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
-typescript@^3.3.3333:
+typescript@3.6.x:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
   integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==


### PR DESCRIPTION
Version 2.1.9 NRK of CasparCG will contain new parameters for audio fades during a sting transition. This PR adds support for a new parameter format and 2 new parameters.

The new format is `STING (MASK="[string]" OVERLAY="[string]" TRIGGER_POINT=[number] AUDIO_FADE_START=[number] AUDIO_FADE_DURATION=[number])`

The new parameters are `AUDIO_FADE_START` and `AUDIO_FADE_DURATION`

This PR is dependent on https://github.com/SuperFlyTV/casparcg-state/pull/37 and https://github.com/SuperFlyTV/casparcg-connection/pull/144