### PR TITLE
fix: Quantel 

### DIFF
--- a/src/devices/quantelGateway.ts
+++ b/src/devices/quantelGateway.ts
@@ -369,7 +369,7 @@ export class QuantelGateway extends EventEmitter {
 			if (isErrorFromISA(e)) {
 				return retryAfterConnect()
 			} else {
-				throw new Error(e) // handle upstream
+				throw e // handle upstream
 			}
 		}
 	}


### PR DESCRIPTION
This is a fix for an error that appears when having restarted the ISA, causing no ports to be created.

I'm merging this in fast-lane, as this causes a critical bug in prod.