### PR TITLE
fix: caching of resolved states not working

### DIFF
--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -621,7 +621,9 @@ export class Conductor extends EventEmitter {
 		let statTimeTimelineResolved: number = 0
 
 		try {
+			/** The point in time this function is run. ( ie "right now") */
 			const now = this.getCurrentTime()
+			/** The point in time we're targeting. (This can be in the future) */
 			let resolveTime: number = this._nextResolveTime
 
 			const estimatedResolveTime = this.estimateResolveTime()
@@ -678,15 +680,17 @@ export class Conductor extends EventEmitter {
 			const deleteParent = (o: TimelineObject) => { delete o['parent'] }
 			_.each(timeline, (o) => applyRecursively(o, deleteParent))
 
+			// Determine if we can use the pre-resolved timeline:
 			let resolvedStates: ResolvedStates
 			if (
 				this._resolvedStates.resolvedStates &&
 				resolveTime >= this._resolvedStates.resolveTime &&
 				resolveTime < this._resolvedStates.resolveTime + RESOLVE_LIMIT_TIME
 			) {
+				// Yes, we can use the previously resolved timeline:
 				resolvedStates = this._resolvedStates.resolvedStates
-
 			} else {
+				// No, we need to resolve the timeline again:
 				let o = await this._resolver.resolveTimeline(
 					resolveTime,
 					timeline,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

We were never setting any value for `this._resolvedStates`, it was only ever being read and reset. This meant that for every point on the timeline where we needed a resolved timeline, we would be recalculating from scratch.
Additionally, we were record the concrete times for we predicted for 'now' pieces, so a second resolve would substitute a different time

But more crucially, this meant that if a timeline had multiple events close to each other, we would get different 'now' times for each of them. Which would result in the a flicker on the program output until the timeline stabilised with concrete times.

This is very visible by commenting out https://github.com/nrkno/tv-automation-server-core/blob/master/meteor/server/api/peripheralDevice.ts#L210, and running an adlib bts. It will restart the clip every ~100ms and fire a callback to set the now time of the piece to an increasing time.
Disabling that line was a hacky way of simulating core being really slow to send an updated timeline after the callback.

* **Other information**:
Possibly related to https://github.com/nrkno/tv-automation-server-core/pull/160
Likely the cause of some of the flicker reports in asana
