### PR TITLE
feat: use p-all instead of Promise.all for better handling when one rejects

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "emberplus": "git+https://github.com/nrkno/tv-automation-emberplus-connection#dist200919_1",
     "hyperdeck-connection": "^0.4.3",
     "osc": "^2.4.0",
+    "p-all": "^3.0.0",
     "p-queue": "^6.4.0",
     "p-timeout": "^3.2.0",
     "request": "^2.88.0",

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -35,6 +35,7 @@ import { SisyfosMessageDevice, DeviceOptionsSisyfosInternal } from './devices/si
 import { SingularLiveDevice, DeviceOptionsSingularLiveInternal } from './devices/singularLive'
 import { VizMSEDevice, DeviceOptionsVizMSEInternal } from './devices/vizMSE'
 import PQueue from 'p-queue'
+import * as PAll from 'p-all'
 import PTimeout from 'p-timeout'
 export { DeviceContainer }
 export { CommandWithContext }
@@ -546,7 +547,9 @@ export class Conductor extends EventEmitter {
 	}
 
 	private _mapAllDevices<T> (fcn: (d: DeviceContainer) => Promise<T>): Promise<T[]> {
-		return Promise.all(_.map(_.values(this.devices), d => fcn(d)))
+		return PAll(_.map(_.values(this.devices), d => () => fcn(d)), {
+			stopOnError: false
+		})
 	}
 
 	/**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4799,6 +4799,13 @@ osc@^2.4.0:
   optionalDependencies:
     serialport "8.0.6"
 
+p-all@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-all/-/p-all-3.0.0.tgz#077c023c37e75e760193badab2bad3ccd5782bfb"
+  integrity sha512-qUZbvbBFVXm6uJ7U/WDiO0fv6waBMbjlCm4E66oZdRR+egswICarIdHyVSZZHudH8T5SF8x/JG0q0duFzPnlBw==
+  dependencies:
+    p-map "^4.0.0"
+
 p-cancelable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
@@ -4853,6 +4860,13 @@ p-map@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-3.0.0.tgz#d704d9af8a2ba684e2600d9a215983d4141a979d"
   integrity sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==
+  dependencies:
+    aggregate-error "^3.0.0"
+
+p-map@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
+  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
 


### PR DESCRIPTION
When using Promise.all, it will reject when the first child rejects. The other children will keep executing until completion.
This will lead to race conditions as we run many of these operations behind a lock to ensure only one happens at a time.

By using p-all, we can tell it to reject only once they have all completed, and so we will retain the lock until they are all done.