### PR TITLE
fix: set interface to stricter typings

### DIFF
--- a/src/types/src/casparcg.ts
+++ b/src/types/src/casparcg.ts
@@ -436,14 +436,14 @@ export interface TransitionObject {
 	outTransition: Transition0
 }
 export interface ITransition {
-	type?: string
+	type?: Transition
 	duration: number
-	easing?: string
-	direction?: string
+	easing?: Ease
+	direction?: Direction | string
 }
 export interface Transition0 extends ITransition {
-	type: string
+	type: Transition
 	duration: number
-	easing: string
-	direction: string
+	easing: Ease
+	direction: Direction | string
 }


### PR DESCRIPTION
This is a small fix in the casparcg-typings.
I found out that we did have defined the enums for `ITransition.easing`, `ITransition.direction` & `ITransition.type`, but we didn't use them.