### PR TITLE
ATEM interface documentation

### DIFF
--- a/src/types/src/atem.ts
+++ b/src/types/src/atem.ts
@@ -132,10 +132,13 @@ export interface TimelineObjAtemME extends TimelineObjAtemBase {
 			input?: number,
 			transition?: AtemTransitionStyle,
 
-			/** To change previewInput you must use programInput to set program directly */
 			/** Cut directly to program */
 			programInput?: number;
-			/** Set preview input (cut) */
+			/**
+			 * Set preview input.
+			 * Cannot be used in conjunction with `input`;
+			 * `programInput` must be used instead if control of program and preview are both needed.
+			 */
 			previewInput?: number;
 			/** Is ME in transition state */
 			inTransition?: boolean;

--- a/src/types/src/atem.ts
+++ b/src/types/src/atem.ts
@@ -117,7 +117,8 @@ export interface TimelineObjAtemME extends TimelineObjAtemBase {
 			input?: number,
 			transition?: AtemTransitionStyle,
 
-			// programInput?: number; // programInput exists, bu I don't think we should use it /Nyman
+			/** Cut directly to program */
+			programInput?: number;
 			previewInput?: number;
 			inTransition?: boolean;
 			transitionPreview?: boolean;

--- a/src/types/src/atem.ts
+++ b/src/types/src/atem.ts
@@ -63,13 +63,20 @@ export enum MediaSourceType { // Note: copied from atem-state
 export type SuperSourceBox = {
 	enabled?: boolean,
 	source?: number,
+	/** -4800 - 4800 */
 	x?: number,
+	/** -2700 - 2700 */
 	y?: number,
+	/** 70 - 1000 */
 	size?: number,
 	cropped?: boolean,
+	/** 0 - 18000 */
 	cropTop?: number,
+	/** 0 - 18000 */
 	cropBottom?: number,
+	/** 0 - 32000 */
 	cropLeft?: number,
+	/** 0 - 32000 */
 	cropRight?: number
 }
 
@@ -81,13 +88,20 @@ export interface AtemTransitionSettings {
 	}
 	// stinger
 	wipe?: {
+		/** 1 - 250 frames */
 		rate?: number,
+		/** 0 - 17 */
 		pattern?: number,
+		/** 0 - 10000 */
 		borderWidth?: number,
 		borderInput?: number,
+		/** 0 - 10000 */
 		symmetry?: number,
+		/** 0 - 10000 */
 		borderSoftness?: number,
+		/** 0 - 10000 */
 		xPosition?: number,
+		/** 0 - 10000 */
 		yPosition?: number,
 		reverseDirection?: boolean,
 		flipFlop?: boolean
@@ -114,33 +128,49 @@ export interface TimelineObjAtemME extends TimelineObjAtemBase {
 		deviceType: DeviceType.ATEM
 		type: TimelineContentTypeAtem.ME
 		me: {
+			/** Must be used with transition property, sets input to transition to */
 			input?: number,
 			transition?: AtemTransitionStyle,
 
+			/** To change previewInput you must use programInput to set program directly */
 			/** Cut directly to program */
 			programInput?: number;
+			/** Set preview input (cut) */
 			previewInput?: number;
+			/** Is ME in transition state */
 			inTransition?: boolean;
+			/** Should preview transition */
 			transitionPreview?: boolean;
+			/** Position of T-bar */
 			transitionPosition?: number;
 			// transitionFramesLeft?: number;
 			// fadeToBlack?: boolean;
 			// numberOfKeyers?: number;
 			// transitionProperties?: AtemTransitionProperties;
 
+			/** Settings for mix rate, wipe style */
 			transitionSettings?: AtemTransitionSettings,
 
 			upstreamKeyers?: {
 				readonly upstreamKeyerId: number,
 				onAir?: boolean
+				/** 0: Luma, 1: Chroma, 2: Pattern, 3: DVE */
 				mixEffectKeyType?: number,
+				/** Use flying key */
 				flyEnabled?: boolean,
+				/** Fill */
 				fillSource?: number,
+				/** Key */
 				cutSource?: number,
+				/** Mask keyer */
 				maskEnabled?: boolean,
+				/** -9000 -> 9000 */
 				maskTop?: number,
+				/** -9000 -> 9000 */
 				maskBottom?: number,
+				/** -16000 -> 16000 */
 				maskLeft?: number,
+				/** -16000 -> 16000 */
 				maskRight?: number,
 
 				// dveSettings: UpstreamKeyerDVESettings;
@@ -149,9 +179,13 @@ export interface TimelineObjAtemME extends TimelineObjAtemBase {
 				// flyKeyframes: Array<UpstreamKeyerFlyKeyframe>;
 				// flyProperties: UpstreamKeyerFlySettings;
 				lumaSettings?: {
+					/** Premultiply key */
 					preMultiplied?: boolean,
+					/** 0-1000 */
 					clip?: number,
+					/** 0-1000 */
 					gain?: number,
+					/** Invert key */
 					invert?: boolean
 				}
 			}[]
@@ -165,21 +199,33 @@ export interface TimelineObjAtemDSK extends TimelineObjAtemBase {
 		dsk: {
 			onAir: boolean,
 			sources?: {
+				/** Fill */
 				fillSource: number,
+				/** Key */
 				cutSource: number
 			},
 			properties?: {
+				/** On at next transition */
 				tie?: boolean,
+				/** 1 - 250 frames */
 				rate?: number,
+				/** Premultiply key */
 				preMultiply?: boolean,
+				/** 0 - 1000 */
 				clip?: number,
+				/** 0 - 1000 */
 				gain?: number,
+				/** Invert key */
 				invert?: boolean,
 				mask?: {
 					enabled: boolean,
+					/** -9000 -> 9000 */
 					top?: number,
+					/** -9000 -> 9000 */
 					bottom?: number,
+					/** -16000 -> 16000 */
 					left?: number,
+					/** -16000 -> 16000 */
 					right?: number
 				}
 			}
@@ -209,9 +255,13 @@ export interface TimelineObjAtemSsrcProps extends TimelineObjAtemBase {
 		deviceType: DeviceType.ATEM
 		type: TimelineContentTypeAtem.SSRCPROPS
 		ssrcProps: {
+			/** Fill */
 			artFillSource: number
+			/** Key */
 			artCutSource: number
+			/** Foreground */
 			artOption: number
+			/** Premultiply key */
 			artPreMultiplied: boolean
 			// artClip: number
 			// artGain: number
@@ -255,8 +305,11 @@ export interface TimelineObjAtemAudioChannel extends TimelineObjAtemBase {
 		deviceType: DeviceType.ATEM
 		type: TimelineContentTypeAtem.AUDIOCHANNEL
 		audioChannel: {
+			/** 0 - 65381 */
 			gain?: number
+			/** -10000 - 10000 */
 			balance?: number
+			/** 0: Off, 1: On, 2: AFV */
 			mixOption?: number
 		}
 	}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Re-enables the `programInput` property of the `me` object, allowing program to be cut directly. This in turn allows the preview source to be set.
- Adds documentation to the ATEM type definitions, including acceptable value ranges for numeric properties.