### PR TITLE
Feat/audio interface combined faders

### DIFF
--- a/src/devices/__tests__/sisyfos.spec.ts
+++ b/src/devices/__tests__/sisyfos.spec.ts
@@ -657,12 +657,12 @@ describe('Sisyfos', () => {
 
 					channels: [
 						{
-							channel: 1,
+							mappedLayer: 'sisyfos_channel_1',
 							faderLevel: 0.1,
 							isPgm: 0
 						},
 						{
-							channel: 2,
+							mappedLayer: 'sisyfos_channel_2',
 							faderLevel: 0.2,
 							isPgm: 0
 						}
@@ -709,11 +709,11 @@ describe('Sisyfos', () => {
 
 					channels: [
 						{
-							channel: 1,
+							mappedLayer: 'sisyfos_channel_1',
 							faderLevel: 0.75
 						},
 						{
-							channel: 2,
+							mappedLayer: 'sisyfos_channel_2',
 							faderLevel: 0.74
 						}
 					],

--- a/src/devices/__tests__/sisyfos.spec.ts
+++ b/src/devices/__tests__/sisyfos.spec.ts
@@ -7,7 +7,7 @@ import {
 import { MockOSC } from '../../__mocks__/osc'
 import { MockTime } from '../../__tests__/mockTime'
 import { ThreadedClass } from 'threadedclass'
-import { MappingSisyfos, TimelineContentTypeSisyfos } from '../../types/src/sisyfos'
+import { MappingSisyfos, TimelineContentTypeSisyfos, MappingSisyfosType } from '../../types/src/sisyfos'
 import { SisyfosMessageDevice } from '../sisyfos'
 import { getMockCall } from '../../__tests__/lib'
 
@@ -36,19 +36,23 @@ describe('Sisyfos', () => {
 		})
 		let myChannelMapping0: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
 			channel: 0
 		}
 		let myChannelMapping1: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
 			channel: 1
 		}
 		let myChannelMapping2: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
 			channel: 1
 		}
+		// @ts-ignore skipping .mappingType to test backwards compatibility
 		let myChannelMapping3: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
 			deviceId: 'mySisyfos',
@@ -91,9 +95,11 @@ describe('Sisyfos', () => {
 					duration: 2000
 				},
 				layer: 'sisyfos_channel_1',
+				// @ts-ignore: for backwards compatibility
 				content: {
 					deviceType: DeviceType.SISYFOS,
-					type: TimelineContentTypeSisyfos.SISYFOS,
+					// @ts-ignore: for backwards compatibility
+					type: 'sisyfos',
 
 					isPgm: 1
 				}
@@ -107,7 +113,7 @@ describe('Sisyfos', () => {
 				layer: 'sisyfos_channel_1',
 				content: {
 					deviceType: DeviceType.SISYFOS,
-					type: TimelineContentTypeSisyfos.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
 
 					isPgm: 2
 				}
@@ -121,7 +127,7 @@ describe('Sisyfos', () => {
 				layer: 'sisyfos_channel_2_lookahead',
 				content: {
 					deviceType: DeviceType.SISYFOS,
-					type: TimelineContentTypeSisyfos.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
 
 					isPgm: 1
 				},
@@ -137,7 +143,7 @@ describe('Sisyfos', () => {
 				layer: 'sisyfos_channel_2',
 				content: {
 					deviceType: DeviceType.SISYFOS,
-					type: TimelineContentTypeSisyfos.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
 
 					isPgm: 1
 				}
@@ -151,7 +157,7 @@ describe('Sisyfos', () => {
 				layer: 'sisyfos_channel_1',
 				content: {
 					deviceType: DeviceType.SISYFOS,
-					type: TimelineContentTypeSisyfos.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
 
 					label: 'MY TIME'
 				}
@@ -165,7 +171,7 @@ describe('Sisyfos', () => {
 				layer: 'sisyfos_channel_1',
 				content: {
 					deviceType: DeviceType.SISYFOS,
-					type: TimelineContentTypeSisyfos.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
 					visible: false
 				}
 			},
@@ -178,7 +184,220 @@ describe('Sisyfos', () => {
 				layer: 'sisyfos_channel_1',
 				content: {
 					deviceType: DeviceType.SISYFOS,
-					type: TimelineContentTypeSisyfos.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
+					visible: true
+				}
+			}
+		]
+
+		await mockTime.advanceTimeTicks(100) // now-ish
+		expect(commandReceiver0.mock.calls.length).toEqual(1)
+		// set pgm
+		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
+			type: 'togglePgm',
+			channel: 0,
+			value: 1
+		})
+
+		await mockTime.advanceTimeTicks(1000) // 1 seconds into the future
+		expect(commandReceiver0.mock.calls.length).toEqual(3)
+		// set VO
+		expect(getMockCall(commandReceiver0, 2, 1)).toMatchObject({
+			type: 'togglePst',
+			channel: 1,
+			value: 1
+		})
+
+		await mockTime.advanceTimeTicks(2000) // 3 seconds into the future
+		expect(commandReceiver0.mock.calls.length).toEqual(5)
+		// set pst
+		expect(getMockCall(commandReceiver0, 3, 1)).toMatchObject({
+			type: 'togglePgm',
+			channel: 1,
+			value: 1
+		})
+
+		await mockTime.advanceTimeTicks(3000) // 6 seconds into the future
+		expect(commandReceiver0.mock.calls.length).toEqual(9)
+		// set pst off
+		expect(getMockCall(commandReceiver0, 4, 1)).toMatchObject({
+			type: 'togglePst',
+			channel: 1,
+			value: 0
+		})
+		// set pst off
+		expect(getMockCall(commandReceiver0, 5, 1)).toMatchObject({
+			type: 'togglePgm',
+			channel: 0,
+			value: 0
+		})
+		// set new label
+		expect(getMockCall(commandReceiver0, 6, 1)).toMatchObject({
+			type: 'label',
+			channel: 0,
+			value: 'MY TIME'
+		})
+		// set visible false
+		expect(getMockCall(commandReceiver0, 8, 1)).toMatchObject({
+			type: 'visible',
+			channel: 0,
+			value: false
+		})
+	})
+	test('Sisyfos: set ch1: pgm & ch2: lookahead and then ch1: vo, ch2: pgm', async () => {
+
+		const commandReceiver0: any = jest.fn(() => {
+			return Promise.resolve()
+		})
+		let myChannelMapping0: MappingSisyfos = {
+			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNEL,
+			deviceId: 'mySisyfos',
+			channel: 0
+		}
+		let myChannelMapping1: MappingSisyfos = {
+			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNEL,
+			deviceId: 'mySisyfos',
+			channel: 1
+		}
+		let myChannelMapping2: MappingSisyfos = {
+			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNEL,
+			deviceId: 'mySisyfos',
+			channel: 1
+		}
+		let myChannelMapping3: MappingSisyfos = {
+			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNEL,
+			deviceId: 'mySisyfos',
+			channel: 3
+		}
+		let myChannelMapping: Mappings = {
+			'sisyfos_channel_1': myChannelMapping0,
+			'sisyfos_channel_2': myChannelMapping1,
+			'sisyfos_channel_2_lookahead': myChannelMapping2,
+			'sisyfos_channel_3': myChannelMapping3
+		}
+
+		let myConductor = new Conductor({
+			initializeAsClear: true,
+			getCurrentTime: mockTime.getCurrentTime
+		})
+		await myConductor.setMapping(myChannelMapping)
+		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
+		await myConductor.addDevice('mySisyfos', {
+			type: DeviceType.SISYFOS,
+			options: {
+				commandReceiver: commandReceiver0,
+				host: '192.168.0.10',
+				port: 8900
+			}
+		})
+		await mockTime.advanceTimeToTicks(10100)
+
+		let deviceContainer = myConductor.getDevice('mySisyfos')
+		let device = deviceContainer.device as ThreadedClass<SisyfosMessageDevice>
+
+		// Check that no commands has been scheduled:
+		expect(await device.queue).toHaveLength(0)
+
+		myConductor.timeline = [
+			{
+				id: 'obj0',
+				enable: {
+					start: mockTime.now - 1000, // 1 seconds in the past
+					duration: 2000
+				},
+				layer: 'sisyfos_channel_1',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
+
+					isPgm: 1
+				}
+			},
+			{
+				id: 'obj1',
+				enable: {
+					start: mockTime.now + 1000, // 1 seconds in the future
+					duration: 4000
+				},
+				layer: 'sisyfos_channel_1',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
+
+					isPgm: 2
+				}
+			},
+			{
+				id: 'obj2',
+				enable: {
+					start: mockTime.now + 1000, // 1 seconds in the future
+					duration: 2000
+				},
+				layer: 'sisyfos_channel_2_lookahead',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
+
+					isPgm: 1
+				},
+				isLookahead: true,
+				lookaheadForLayer: 'sisyfos_channel_2'
+			},
+			{
+				id: 'obj3',
+				enable: {
+					start: mockTime.now + 3000, // 3 seconds in the future
+					duration: 2000
+				},
+				layer: 'sisyfos_channel_2',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
+
+					isPgm: 1
+				}
+			},
+			{
+				id: 'obj5',
+				enable: {
+					start: mockTime.now + 5000, // 5 seconds in the future
+					duration: 2000
+				},
+				layer: 'sisyfos_channel_1',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
+
+					label: 'MY TIME'
+				}
+			},
+			{
+				id: 'obj6',
+				enable: {
+					start: mockTime.now + 6000, // 6 seconds in the future
+					duration: 900
+				},
+				layer: 'sisyfos_channel_1',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
+					visible: false
+				}
+			},
+			{
+				id: 'obj7',
+				enable: {
+					start: mockTime.now + 7000, // 7 seconds in the future
+					duration: 900
+				},
+				layer: 'sisyfos_channel_1',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
 					visible: true
 				}
 			}
@@ -246,21 +465,25 @@ describe('Sisyfos', () => {
 		})
 		let myChannelMapping0: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
 			channel: 0
 		}
 		let myChannelMapping1: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
 			channel: 1
 		}
 		let myChannelMapping2: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
 			channel: 1
 		}
 		let myChannelMapping3: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
 			channel: 3
 		}
@@ -303,7 +526,7 @@ describe('Sisyfos', () => {
 				layer: 'sisyfos_channel_2_lookahead',
 				content: {
 					deviceType: DeviceType.SISYFOS,
-					type: TimelineContentTypeSisyfos.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
 
 					isPgm: 1
 				},
@@ -319,7 +542,7 @@ describe('Sisyfos', () => {
 				layer: 'sisyfos_channel_2',
 				content: {
 					deviceType: DeviceType.SISYFOS,
-					type: TimelineContentTypeSisyfos.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
 
 					isPgm: 1
 				}
@@ -333,7 +556,7 @@ describe('Sisyfos', () => {
 				layer: 'sisyfos_channel_2_lookahead',
 				content: {
 					deviceType: DeviceType.SISYFOS,
-					type: TimelineContentTypeSisyfos.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
 
 					isPgm: 0
 				},
@@ -363,6 +586,207 @@ describe('Sisyfos', () => {
 			channel: 1,
 			value: 0
 		})
+	})
+
+	test('Sisyfos: using CHANNELS', async () => {
+
+		const commandReceiver0: any = jest.fn(() => {
+			return Promise.resolve()
+		})
+		let myChannelMapping0: MappingSisyfos = {
+			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNELS,
+			deviceId: 'mySisyfos'
+		}
+		let myChannelMapping1: MappingSisyfos = {
+			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNEL,
+			deviceId: 'mySisyfos',
+			channel: 1
+		}
+		let myChannelMapping2: MappingSisyfos = {
+			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNEL,
+			deviceId: 'mySisyfos',
+			channel: 2
+		}
+		let myChannelMapping3: MappingSisyfos = {
+			device: DeviceType.SISYFOS,
+			mappingType: MappingSisyfosType.CHANNELS,
+			deviceId: 'mySisyfos'
+		}
+		let myChannelMapping: Mappings = {
+			'sisyfos_channels_base': myChannelMapping0,
+			'sisyfos_channel_1': myChannelMapping1,
+			'sisyfos_channel_2': myChannelMapping2,
+			'sisyfos_channels': myChannelMapping3
+		}
+
+		let myConductor = new Conductor({
+			initializeAsClear: true,
+			getCurrentTime: mockTime.getCurrentTime
+		})
+		await myConductor.setMapping(myChannelMapping)
+		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
+		await myConductor.addDevice('mySisyfos', {
+			type: DeviceType.SISYFOS,
+			options: {
+				commandReceiver: commandReceiver0,
+				host: '192.168.0.10',
+				port: 8900
+			}
+		})
+		await mockTime.advanceTimeToTicks(10100)
+
+		let deviceContainer = myConductor.getDevice('mySisyfos')
+		let device = deviceContainer.device as ThreadedClass<SisyfosMessageDevice>
+
+		// Check that no commands has been scheduled:
+		expect(await device.queue).toHaveLength(0)
+
+		myConductor.timeline = [
+			{
+				id: 'baseline',
+				enable: {
+					while: 1
+				},
+				layer: 'sisyfos_channels_base',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNELS,
+
+					channels: [
+						{
+							channel: 1,
+							faderLevel: 0.1,
+							isPgm: 0
+						},
+						{
+							channel: 2,
+							faderLevel: 0.2,
+							isPgm: 0
+						}
+					],
+					overridePriority: -999
+				}
+			},
+			{
+				id: 'obj1',
+				enable: {
+					start: mockTime.now + 1000, // 1 seconds in the future
+					duration: 10000
+				},
+				layer: 'sisyfos_channel_1',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
+					isPgm: 1
+				}
+			},
+			{
+				id: 'obj2',
+				enable: {
+					start: mockTime.now + 2000, // 2 seconds in the future
+					duration: 2000
+				},
+				layer: 'sisyfos_channel_2',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
+					isPgm: 1
+				}
+			},
+			{
+				id: 'obj3',
+				enable: {
+					start: mockTime.now + 3000, // 3 seconds in the future
+					duration: 1000
+				},
+				layer: 'sisyfos_channels',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNELS,
+
+					channels: [
+						{
+							channel: 1,
+							faderLevel: 0.75
+						},
+						{
+							channel: 2,
+							faderLevel: 0.74
+						}
+					],
+					overridePriority: -999
+				}
+			}
+		]
+
+		// baseline:
+		await mockTime.advanceTimeTicks(100) // 100
+		expect(commandReceiver0.mock.calls.length).toEqual(1)
+		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
+			type: 'setFader',
+			channel: 1,
+			value: 0.1
+		})
+		commandReceiver0.mockClear()
+
+		// obj1 has started
+		await mockTime.advanceTimeTicks(1000) // 1100
+		expect(commandReceiver0.mock.calls.length).toEqual(1)
+		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
+			type: 'togglePgm',
+			channel: 1,
+			value: 1
+		})
+		commandReceiver0.mockClear()
+
+		// obj2 has started
+		await mockTime.advanceTimeTicks(1000) // 2100
+		expect(commandReceiver0.mock.calls.length).toEqual(1)
+		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
+			type: 'togglePgm',
+			channel: 2,
+			value: 1
+		})
+		commandReceiver0.mockClear()
+
+		// obj3 has started
+		await mockTime.advanceTimeTicks(1000) // 3100
+		expect(commandReceiver0.mock.calls.length).toEqual(2)
+		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
+			type: 'setFader',
+			channel: 1,
+			value: 0.75
+		})
+		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
+			type: 'setFader',
+			channel: 2,
+			value: 0.74
+		})
+		commandReceiver0.mockClear()
+
+		// obj3 & obj2 has ended
+		await mockTime.advanceTimeTicks(1000) // 4100
+		expect(commandReceiver0.mock.calls.length).toEqual(3)
+		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
+			type: 'setFader',
+			channel: 1,
+			value: 0.1
+		})
+		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
+			type: 'togglePgm',
+			channel: 2,
+			value: 0
+		})
+		expect(getMockCall(commandReceiver0, 2, 1)).toMatchObject({
+			type: 'setFader',
+			channel: 2,
+			value: 0.2
+		})
+
+		commandReceiver0.mockClear()
 	})
 
 	test('Connection status', async () => {

--- a/src/devices/__tests__/sisyfosAPI.spec.ts
+++ b/src/devices/__tests__/sisyfosAPI.spec.ts
@@ -1,5 +1,5 @@
 jest.mock('osc')
-import { SisyfosInterface } from '../sisyfosAPI'
+import { SisyfosApi } from '../sisyfosAPI'
 import { MockOSC } from '../../__mocks__/osc'
 
 const orgSetTimeout = setTimeout
@@ -22,7 +22,7 @@ describe('SisyfosAPI', () => {
 		let onConnected = jest.fn()
 		let onDisconnected = jest.fn()
 
-		let sisyfos = new SisyfosInterface()
+		let sisyfos = new SisyfosApi()
 		sisyfos.on('error', onError)
 		sisyfos.on('initialized', onInitialized)
 		sisyfos.on('connected', onConnected)

--- a/src/devices/sisyfos.ts
+++ b/src/devices/sisyfos.ts
@@ -15,8 +15,18 @@ import { DoOnTime, SendMode } from '../doOnTime'
 import {
 	TimelineState, ResolvedTimelineObjectInstance
 } from 'superfly-timeline'
-import { SisyfosOptions, SisyfosState, SisyfosChannel, TimelineObjSisyfosMessage, MappingSisyfos, Commands, SisyfosCommand } from '../types/src/sisyfos'
-import { SisyfosInterface } from './sisyfosAPI'
+import {
+	SisyfosOptions,
+	TimelineObjSisyfosMessage,
+	MappingSisyfos
+} from '../types/src/sisyfos'
+import {
+	SisyfosApi,
+	SisyfosCommand,
+	SisyfosState,
+	SisyfosChannel,
+	SisyfosCommandType
+} from './sisyfosAPI'
 
 export interface DeviceOptionsSisyfosInternal extends DeviceOptionsSisyfos {
 	options: (
@@ -37,7 +47,7 @@ type CommandContext = string
 export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implements IDevice {
 
 	private _doOnTime: DoOnTime
-	private _sisyfos: SisyfosInterface
+	private _sisyfos: SisyfosApi
 
 	private _commandReceiver: CommandReceiver
 
@@ -50,7 +60,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 			else this._commandReceiver = this._defaultCommandReceiver
 		}
 
-		this._sisyfos = new SisyfosInterface()
+		this._sisyfos = new SisyfosApi()
 		this._sisyfos.on('error', e => this.emit('error', 'Sisyfos', e))
 		this._sisyfos.on('connected', () => {
 			this._connectionChanged()
@@ -296,7 +306,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 				{
 					context: `Resyncing with Sisyfos`,
 					content: {
-						type: Commands.RESYNC
+						type: SisyfosCommandType.RESYNC
 					},
 					timelineObjId: ''
 				}
@@ -310,7 +320,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 				commands.push({
 					context: `Channel ${index} pgm goes from "${oldChannel.pgmOn}" to "${newChannel.pgmOn}"`,
 					content: {
-						type: Commands.TOGGLE_PGM,
+						type: SisyfosCommandType.TOGGLE_PGM,
 						channel: Number(index),
 						value: newChannel.pgmOn
 					},
@@ -322,7 +332,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 				commands.push({
 					context: `Channel ${index} pst goes from "${oldChannel.pstOn}" to "${newChannel.pstOn}"`,
 					content: {
-						type: Commands.TOGGLE_PST,
+						type: SisyfosCommandType.TOGGLE_PST,
 						channel: Number(index),
 						value: newChannel.pstOn
 					},
@@ -334,7 +344,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 				commands.push({
 					context: 'faderLevel change',
 					content: {
-						type: Commands.SET_FADER,
+						type: SisyfosCommandType.SET_FADER,
 						channel: Number(index),
 						value: newChannel.faderLevel
 					},
@@ -347,7 +357,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 				commands.push({
 					context: 'set label on fader',
 					content: {
-						type: Commands.LABEL,
+						type: SisyfosCommandType.LABEL,
 						channel: Number(index),
 						value: newChannel.label
 					},
@@ -359,7 +369,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 				commands.push({
 					context: `Channel ${index} Visibility goes from "${oldChannel.visible}" to "${newChannel.visible}"`,
 					content: {
-						type: Commands.VISIBLE,
+						type: SisyfosCommandType.VISIBLE,
 						channel: Number(index),
 						value: newChannel.visible
 					},
@@ -379,7 +389,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 		}
 		this.emit('debug', cwc)
 
-		if (cmd.type === Commands.RESYNC) {
+		if (cmd.type === SisyfosCommandType.RESYNC) {
 			return this._makeReadyInner(true, true)
 		} else {
 			try {

--- a/src/devices/sisyfos.ts
+++ b/src/devices/sisyfos.ts
@@ -276,7 +276,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 				// @ts-ignore backwards-compatibility:
 				if (!foundMapping.mappingType) foundMapping.mappingType = MappingSisyfosType.CHANNEL
 				// @ts-ignore backwards-compatibility:
-				if (!content.type === 'sisyfos') content.type = TimelineContentTypeSisyfos.CHANNEL
+				if (content.type === 'sisyfos') content.type = TimelineContentTypeSisyfos.CHANNEL
 
 				if (
 					foundMapping.mappingType === MappingSisyfosType.CHANNEL &&

--- a/src/devices/sisyfos.ts
+++ b/src/devices/sisyfos.ts
@@ -223,7 +223,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 			if (isDefaultState) { // reset values for default state
 				channel = {
 					...channel,
-					...this.getDefaultStatChannel()
+					...this.getDefaultStateChannel()
 				}
 			}
 
@@ -231,7 +231,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 		}
 		return deviceState
 	}
-	getDefaultStatChannel (): SisyfosChannel {
+	getDefaultStateChannel (): SisyfosChannel {
 		return {
 			faderLevel: 0.75,  // 0 dB
 			pgmOn: 0,
@@ -316,7 +316,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 				_.sortBy(newChannels, channel => channel.overridePriority),
 				newChannel => {
 					if (!deviceState.channels[newChannel.channel]) {
-						deviceState.channels[newChannel.channel] = this.getDefaultStatChannel()
+						deviceState.channels[newChannel.channel] = this.getDefaultStateChannel()
 					}
 					const channel = deviceState.channels[newChannel.channel]
 

--- a/src/types/src/sisyfos.ts
+++ b/src/types/src/sisyfos.ts
@@ -25,55 +25,6 @@ export interface SisyfosCommandContent {
 }
 export type TimelineObjSisyfosAny = TimelineObjSisyfosMessage
 
-export enum Commands {
-	TOGGLE_PGM = 'togglePgm',
-	TOGGLE_PST = 'togglePst',
-	SET_FADER = 'setFader',
-	CLEAR_PST_ROW = 'clearPstRow',
-	LABEL = 'label',
-	TAKE = 'take',
-	VISIBLE = 'visible',
-	RESYNC = 'resync'
-}
-
-export interface BaseCommand {
-	type: Commands
-}
-
-export interface ChannelCommand {
-	type: Commands.SET_FADER | Commands.TOGGLE_PGM | Commands.TOGGLE_PST | Commands.LABEL | Commands.VISIBLE
-	channel: number
-	value: boolean | number | string
-}
-
-export interface BoolCommand extends ChannelCommand {
-	type: Commands.VISIBLE
-	value: boolean
-}
-export interface ValueCommand extends ChannelCommand {
-	type: Commands.TOGGLE_PGM | Commands.TOGGLE_PST | Commands.SET_FADER
-	value: number
-}
-
-export interface StringCommand extends ChannelCommand {
-	type: Commands.LABEL
-	value: string
-}
-
-export interface ResyncCommand extends BaseCommand {
-	type: Commands.RESYNC
-}
-
-export type SisyfosCommand = BaseCommand | ValueCommand | BoolCommand | StringCommand | ResyncCommand
-
-export interface SisyfosChannel extends SisyfosAPIChannel {
-	tlObjIds: string[]
-}
-
-export interface SisyfosState {
-	channels: { [index: string]: SisyfosChannel }
-	resync: boolean
-}
 
 export interface TimelineObjSisyfos extends TSRTimelineObjBase {
 	content: {
@@ -86,19 +37,3 @@ export interface TimelineObjSisyfosMessage extends TimelineObjSisyfos {
 		deviceType: DeviceType.SISYFOS
 	} & SisyfosCommandContent
 }
-// ------------------------------------------------------
-// Interfaces for the data that comes over OSC:
-export interface SisyfosAPIChannel {
-	faderLevel: number
-	pgmOn: number
-	pstOn: number
-	label: string
-	visible: boolean
-}
-
-export interface SisyfosAPIState {
-	channels: {
-		[index: string]: SisyfosAPIChannel
-	}
-}
-// ------------------------------------------------------

--- a/src/types/src/sisyfos.ts
+++ b/src/types/src/sisyfos.ts
@@ -60,7 +60,8 @@ export interface TimelineObjSisyfosChannels extends TimelineObjSisyfos {
 		type: TimelineContentTypeSisyfos.CHANNELS
 		channels: (
 			{
-				channel: number
+				/** The mapping layer to look up the channel from */
+				mappedLayer: string
 			} & SisyfosChannelOptions
 		)[],
 		resync?: boolean

--- a/src/types/src/sisyfos.ts
+++ b/src/types/src/sisyfos.ts
@@ -6,25 +6,31 @@ export interface SisyfosOptions {
 	port: number
 }
 
-export interface MappingSisyfos extends Mapping {
+export enum MappingSisyfosType {
+	CHANNEL = 'channel',
+	CHANNELS = 'channels'
+}
+export type MappingSisyfos = MappingSisyfosChannel | MappingSisyfosChannels
+interface MappingSisyfosBase extends Mapping {
 	device: DeviceType.SISYFOS
+	mappingType: MappingSisyfosType  // defaults to MappingSisyfosType.CHANNEL if not set
+}
+export interface MappingSisyfosChannel extends MappingSisyfosBase {
+	mappingType: MappingSisyfosType.CHANNEL
 	channel: number
+}
+export interface MappingSisyfosChannels extends MappingSisyfosBase {
+	mappingType: MappingSisyfosType.CHANNELS
 }
 
 export enum TimelineContentTypeSisyfos {
-	SISYFOS = 'sisyfos'
+	/** @deprecated use CHANNEL instead */
+	SISYFOS = 'sisyfos',
+	CHANNEL = 'channel',
+	CHANNELS = 'channels'
 }
 
-export interface SisyfosCommandContent {
-	type: TimelineContentTypeSisyfos.SISYFOS
-	isPgm?: number // 0=off 1=PGM 2=VO
-	faderLevel?: number
-	label?: string
-	visible?: boolean
-	resync?: boolean
-}
-export type TimelineObjSisyfosAny = TimelineObjSisyfosMessage
-
+export type TimelineObjSisyfosAny = TimelineObjSisyfosChannel | TimelineObjSisyfosChannels
 
 export interface TimelineObjSisyfos extends TSRTimelineObjBase {
 	content: {
@@ -32,8 +38,35 @@ export interface TimelineObjSisyfos extends TSRTimelineObjBase {
 		type: TimelineContentTypeSisyfos
 	}
 }
-export interface TimelineObjSisyfosMessage extends TimelineObjSisyfos {
+
+export interface SisyfosChannelOptions {
+	isPgm?: 0 | 1 | 2 // 0=off 1=PGM 2=VO
+	faderLevel?: number
+	label?: string
+	visible?: boolean
+}
+
+export interface TimelineObjSisyfosChannel extends TimelineObjSisyfos {
 	content: {
 		deviceType: DeviceType.SISYFOS
-	} & SisyfosCommandContent
+		type: TimelineContentTypeSisyfos.CHANNEL
+		resync?: boolean
+		overridePriority?: number // defaults to 0
+	} & SisyfosChannelOptions
 }
+export interface TimelineObjSisyfosChannels extends TimelineObjSisyfos {
+	content: {
+		deviceType: DeviceType.SISYFOS
+		type: TimelineContentTypeSisyfos.CHANNELS
+		channels: (
+			{
+				channel: number
+			} & SisyfosChannelOptions
+		)[],
+		resync?: boolean
+		overridePriority?: number // defaults to 0
+	}
+}
+// Backwards compatibility:
+/** @deprecated use TimelineObjSisyfosChannel instead */
+export type TimelineObjSisyfosMessage = TimelineObjSisyfosChannel


### PR DESCRIPTION
This PR gives the timeline author the ability to define multiple Sisyfos-channels in a single object.
This will help with reducing the number of mapping-layers and timeline-objects needed to do basic stuff.

Example:
```
{
  id: 'baseline',
  enable: {
    while: 1
  },
  layer: 'sisyfos_channels_base',
  content: {
    deviceType: DeviceType.SISYFOS,
    type: TimelineContentTypeSisyfos.CHANNELS,

    channels: [
      {
        channel: 1,
        faderLevel: 0.1,
        isPgm: 0
      },
      {
        channel: 2,
        faderLevel: 0.2,
        isPgm: 0
      }
    ],
    overridePriority: -999
  }
},
```
This is an added feature, I've taken measures to ensure backwards compatibility with existing timeline-objects.
