### PR TITLE
Feat: audio interface combined faders for Lawo

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,7 @@ Pull up a fader, and leave it there
 		deviceType: DeviceType.LAWO,
 		type: TimelineContentTypeLawo.SOURCE,
 
-		'Fader/Motor dB Value': {
-			value: 0
-		}
+		faderValue: 0
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "atem-state": "^0.9.0",
     "casparcg-connection": "^4.9.0",
     "casparcg-state": "^1.12.0",
-    "emberplus-connection": "^0.0.2",
+    "emberplus-connection": "^0.0.3-nightly-20200622-114815-88534e2.0",
     "hyperdeck-connection": "^0.4.3",
     "osc": "^2.4.0",
     "p-all": "^3.0.0",

--- a/src/devices/__tests__/lawo.spec.ts
+++ b/src/devices/__tests__/lawo.spec.ts
@@ -181,6 +181,401 @@ describe('Lawo', () => {
 		expect(commandReceiver0).toHaveBeenCalledTimes(3)
 		// no new commands should be sent, nothing is sent on object end
 	})
+	test('Lawo: Change volume on multiple faders', async () => {
+
+		const commandReceiver0: any = jest.fn(() => {
+			return Promise.resolve()
+		})
+		let myChannelMapping0: MappingLawo = {
+			device: DeviceType.LAWO,
+			deviceId: 'myLawo',
+			mappingType: MappingLawoType.SOURCE,
+			identifier: 'BASE'
+		}
+		let myChannelMapping1: MappingLawo = {
+			device: DeviceType.LAWO,
+			deviceId: 'myLawo',
+			mappingType: MappingLawoType.SOURCE,
+			identifier: 'BASE2'
+		}
+		let myChannelsMapping: MappingLawo = {
+			device: DeviceType.LAWO,
+			deviceId: 'myLawo',
+			mappingType: MappingLawoType.SOURCES
+		}
+		let myRetriggerMapping: MappingLawo = {
+			device: DeviceType.LAWO,
+			deviceId: 'myLawo',
+			mappingType: MappingLawoType.TRIGGER_VALUE
+		}
+		let myChannelMapping: Mappings = {
+			'lawo_c1_fader': myChannelMapping0,
+			'lawo_c2_fader': myChannelMapping1,
+			'lawo_base': myChannelsMapping,
+			'lawo_trigger': myRetriggerMapping
+		}
+
+		let myConductor = new Conductor({
+			initializeAsClear: true,
+			getCurrentTime: mockTime.getCurrentTime
+		})
+		await myConductor.setMapping(myChannelMapping)
+		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
+		await myConductor.addDevice('myLawo', {
+			type: DeviceType.LAWO,
+			options: {
+				host: '160.67.96.51',
+				port: 9000,
+				commandReceiver: commandReceiver0,
+
+				deviceMode: LawoDeviceMode.Ruby
+			}
+		})
+		await mockTime.advanceTimeToTicks(10100)
+
+		let deviceContainer = myConductor.getDevice('myLawo')
+		let device = deviceContainer.device as ThreadedClass<LawoDevice>
+
+		// Check that no commands has been scheduled:
+		expect(await device.queue).toHaveLength(0)
+		myConductor.timeline = [
+			{
+				id: 'obj0',
+				enable: {
+					start: mockTime.now - 1000, // 1 seconds in the past
+					duration: 2000
+				},
+				layer: 'lawo_base',
+				content: {
+					deviceType: DeviceType.LAWO,
+					type: TimelineContentTypeLawo.SOURCES,
+
+					sources: [{
+						mappingName: 'lawo_c1_fader',
+						value: -6
+					},{
+						mappingName: 'lawo_c2_fader',
+						value: -6
+					}]
+				}
+			},
+			{
+				id: 'obj1',
+				enable: {
+					start: mockTime.now + 500, // 0.5 seconds in the future
+					duration: 2000
+				},
+				layer: 'lawo_base',
+				content: {
+					deviceType: DeviceType.LAWO,
+					type: TimelineContentTypeLawo.SOURCES,
+
+					sources: [{
+						mappingName: 'lawo_c1_fader',
+						value: -4,
+						transitionDuration: 400
+					},{
+						mappingName: 'lawo_c2_fader',
+						value: -4,
+						transitionDuration: 400
+					}]
+				}
+			},
+			{
+				id: 'obj2',
+				enable: {
+					start: mockTime.now + 1000, // 1 seconds in the future
+					duration: 2000
+				},
+				layer: 'lawo_base',
+				content: {
+					deviceType: DeviceType.LAWO,
+					type: TimelineContentTypeLawo.SOURCES,
+
+					sources: [{
+						mappingName: 'lawo_c1_fader',
+						value: -4,
+						transitionDuration: 400
+					},{
+						mappingName: 'lawo_c2_fader',
+						value: -4,
+						transitionDuration: 400
+					}]
+				}
+			},
+			{
+				id: 'obj3',
+				enable: {
+					start: mockTime.now + 2000, // 2 seconds in the future
+					duration: 2000
+				},
+				layer: 'lawo_trigger',
+				content: {
+					deviceType: DeviceType.LAWO,
+					type: TimelineContentTypeLawo.TRIGGER_VALUE,
+
+					triggerValue: 'asdf' // only used for trigging new command sent
+				}
+			}
+		]
+
+		await mockTime.advanceTimeToTicks(10200)
+
+		expect(commandReceiver0).toHaveBeenCalledTimes(2)
+		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject(
+			{
+				// attribute: 'Motor dB Value',
+				type: TimelineContentTypeLawo.SOURCE,
+				value: -6,
+				path: 'Ruby.Sources.BASE.Fader.Motor dB Value'
+			}
+		)
+		expect(getMockCall(commandReceiver0, 0, 2)).toBeTruthy()
+		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject(
+			{
+				// attribute: 'Motor dB Value',
+				type: TimelineContentTypeLawo.SOURCE,
+				value: -6,
+				path: 'Ruby.Sources.BASE2.Fader.Motor dB Value'
+			}
+		)
+		expect(getMockCall(commandReceiver0, 1, 2)).toBeTruthy()
+
+		await mockTime.advanceTimeToTicks(11000)
+
+		expect(commandReceiver0).toHaveBeenCalledTimes(4)
+		expect(getMockCall(commandReceiver0, 2, 1)).toMatchObject(
+			{
+				// attribute: 'Motor dB Value',
+				type: TimelineContentTypeLawo.SOURCE,
+				value: -4,
+				transitionDuration: 400,
+				path: 'Ruby.Sources.BASE.Fader.Motor dB Value'
+			}
+		)
+		expect(getMockCall(commandReceiver0, 2, 2)).toBeTruthy() // context
+		expect(getMockCall(commandReceiver0, 3, 1)).toMatchObject(
+			{
+				// attribute: 'Motor dB Value',
+				type: TimelineContentTypeLawo.SOURCE,
+				value: -4,
+				transitionDuration: 400,
+				path: 'Ruby.Sources.BASE2.Fader.Motor dB Value'
+			}
+		)
+		expect(getMockCall(commandReceiver0, 3, 2)).toBeTruthy() // context
+
+		await mockTime.advanceTimeToTicks(11500)
+		expect(commandReceiver0).toHaveBeenCalledTimes(4)
+		// no new commands should have been sent, becuse obj2 is the same as obj1
+
+		await mockTime.advanceTimeToTicks(12500)
+		expect(commandReceiver0).toHaveBeenCalledTimes(6)
+		expect(getMockCall(commandReceiver0, 4, 1)).toMatchObject(
+			{
+				// attribute: 'Motor dB Value',
+				type: TimelineContentTypeLawo.SOURCE,
+				value: -4,
+				path: 'Ruby.Sources.BASE.Fader.Motor dB Value'
+			}
+		)
+		expect(getMockCall(commandReceiver0, 4, 2)).toMatch(/triggerValue/i) // context
+		expect(getMockCall(commandReceiver0, 5, 1)).toMatchObject(
+			{
+				// attribute: 'Motor dB Value',
+				type: TimelineContentTypeLawo.SOURCE,
+				value: -4,
+				path: 'Ruby.Sources.BASE2.Fader.Motor dB Value'
+			}
+		)
+		expect(getMockCall(commandReceiver0, 5, 2)).toMatch(/triggerValue/i) // context
+		await mockTime.advanceTimeToTicks(14500)
+		expect(commandReceiver0).toHaveBeenCalledTimes(6)
+		// no new commands should be sent, nothing is sent on object end
+	})
+	test('Lawo: Change volume on multiple faders with priorities', async () => {
+
+		const commandReceiver0: any = jest.fn(() => {
+			return Promise.resolve()
+		})
+		let myChannelMapping0: MappingLawo = {
+			device: DeviceType.LAWO,
+			deviceId: 'myLawo',
+			mappingType: MappingLawoType.SOURCE,
+			identifier: 'SOURCE1'
+		}
+		let myChannelMapping1: MappingLawo = {
+			device: DeviceType.LAWO,
+			deviceId: 'myLawo',
+			mappingType: MappingLawoType.SOURCE,
+			identifier: 'SOURCE2'
+		}
+		let myChannelsMapping: MappingLawo = {
+			device: DeviceType.LAWO,
+			deviceId: 'myLawo',
+			mappingType: MappingLawoType.SOURCES
+		}
+		let myRetriggerMapping: MappingLawo = {
+			device: DeviceType.LAWO,
+			deviceId: 'myLawo',
+			mappingType: MappingLawoType.TRIGGER_VALUE
+		}
+		let myChannelMapping: Mappings = {
+			'lawo_c1_fader': myChannelMapping0,
+			'lawo_c2_fader': myChannelMapping1,
+			'lawo_base': myChannelsMapping,
+			'lawo_trigger': myRetriggerMapping
+		}
+
+		let myConductor = new Conductor({
+			initializeAsClear: true,
+			getCurrentTime: mockTime.getCurrentTime
+		})
+		await myConductor.setMapping(myChannelMapping)
+		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
+		await myConductor.addDevice('myLawo', {
+			type: DeviceType.LAWO,
+			options: {
+				host: '160.67.96.51',
+				port: 9000,
+				commandReceiver: commandReceiver0,
+
+				deviceMode: LawoDeviceMode.Ruby
+			}
+		})
+		await mockTime.advanceTimeToTicks(10100)
+
+		let deviceContainer = myConductor.getDevice('myLawo')
+		let device = deviceContainer.device as ThreadedClass<LawoDevice>
+
+		// Check that no commands has been scheduled:
+		expect(await device.queue).toHaveLength(0)
+		myConductor.timeline = [
+			{
+				id: 'obj0',
+				enable: {
+					start: mockTime.now - 1000, // 1 seconds in the past
+					duration: 2000
+				},
+				layer: 'lawo_base',
+				content: {
+					deviceType: DeviceType.LAWO,
+					type: TimelineContentTypeLawo.SOURCES,
+
+					sources: [{
+						mappingName: 'lawo_c1_fader',
+						value: -6
+					},{
+						mappingName: 'lawo_c2_fader',
+						value: -6
+					}]
+				}
+			},
+			{
+				id: 'obj1',
+				enable: {
+					start: mockTime.now - 1000, // 1 seconds in the past
+					duration: 2000
+				},
+				layer: 'lawo_c1_fader',
+				content: {
+					deviceType: DeviceType.LAWO,
+					type: TimelineContentTypeLawo.SOURCE,
+
+					value: 0,
+					overridePriority: 1
+				}
+			},
+			{
+				id: 'obj2',
+				enable: {
+					start: mockTime.now + 500, // 0.5 seconds in the future
+					duration: 2000
+				},
+				layer: 'lawo_base',
+				content: {
+					deviceType: DeviceType.LAWO,
+					type: TimelineContentTypeLawo.SOURCES,
+
+					sources: [{
+						mappingName: 'lawo_c1_fader',
+						value: -4,
+						transitionDuration: 400
+					},{
+						mappingName: 'lawo_c2_fader',
+						value: -4,
+						transitionDuration: 400
+					}],
+					overridePriority: 1
+				}
+			},
+			{
+				id: 'obj3',
+				enable: {
+					start: mockTime.now + 500, // 0.5 seconds in the future
+					duration: 2000
+				},
+				layer: 'lawo_c1_fader',
+				content: {
+					deviceType: DeviceType.LAWO,
+					type: TimelineContentTypeLawo.SOURCE,
+
+					value: -12,
+					transitionDuration: 400
+				}
+			},
+		]
+
+		await mockTime.advanceTimeToTicks(10200)
+
+		expect(commandReceiver0).toHaveBeenCalledTimes(2)
+		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject(
+			{
+				// attribute: 'Motor dB Value',
+				type: TimelineContentTypeLawo.SOURCE,
+				value: 0,
+				path: 'Ruby.Sources.SOURCE1.Fader.Motor dB Value'
+			}
+		)
+		expect(getMockCall(commandReceiver0, 0, 2)).toBeTruthy()
+		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject(
+			{
+				// attribute: 'Motor dB Value',
+				type: TimelineContentTypeLawo.SOURCE,
+				value: -6,
+				path: 'Ruby.Sources.SOURCE2.Fader.Motor dB Value'
+			}
+		)
+		expect(getMockCall(commandReceiver0, 1, 2)).toBeTruthy()
+
+		await mockTime.advanceTimeToTicks(11000)
+
+		expect(commandReceiver0).toHaveBeenCalledTimes(4)
+		expect(getMockCall(commandReceiver0, 2, 1)).toMatchObject(
+			{
+				// attribute: 'Motor dB Value',
+				type: TimelineContentTypeLawo.SOURCE,
+				value: -4,
+				transitionDuration: 400,
+				path: 'Ruby.Sources.SOURCE1.Fader.Motor dB Value'
+			}
+		)
+		expect(getMockCall(commandReceiver0, 2, 2)).toBeTruthy() // context
+		expect(getMockCall(commandReceiver0, 3, 1)).toMatchObject(
+			{
+				// attribute: 'Motor dB Value',
+				type: TimelineContentTypeLawo.SOURCE,
+				value: -4,
+				transitionDuration: 400,
+				path: 'Ruby.Sources.SOURCE2.Fader.Motor dB Value'
+			}
+		)
+		expect(getMockCall(commandReceiver0, 3, 2)).toBeTruthy() // context
+
+		await mockTime.advanceTimeToTicks(14500)
+		expect(commandReceiver0).toHaveBeenCalledTimes(4)
+		// no new commands should be sent, nothing is sent on object end
+	})
 	test('Lawo: Set delay om main/pgm', async () => {
 
 		const commandReceiver0: any = jest.fn(() => {

--- a/src/devices/__tests__/lawo.spec.ts
+++ b/src/devices/__tests__/lawo.spec.ts
@@ -252,10 +252,10 @@ describe('Lawo', () => {
 
 					sources: [{
 						mappingName: 'lawo_c1_fader',
-						value: -6
+						faderValue: -6
 					},{
 						mappingName: 'lawo_c2_fader',
-						value: -6
+						faderValue: -6
 					}]
 				}
 			},
@@ -272,11 +272,11 @@ describe('Lawo', () => {
 
 					sources: [{
 						mappingName: 'lawo_c1_fader',
-						value: -4,
+						faderValue: -4,
 						transitionDuration: 400
 					},{
 						mappingName: 'lawo_c2_fader',
-						value: -4,
+						faderValue: -4,
 						transitionDuration: 400
 					}]
 				}
@@ -294,11 +294,11 @@ describe('Lawo', () => {
 
 					sources: [{
 						mappingName: 'lawo_c1_fader',
-						value: -4,
+						faderValue: -4,
 						transitionDuration: 400
 					},{
 						mappingName: 'lawo_c2_fader',
-						value: -4,
+						faderValue: -4,
 						transitionDuration: 400
 					}]
 				}
@@ -464,10 +464,10 @@ describe('Lawo', () => {
 
 					sources: [{
 						mappingName: 'lawo_c1_fader',
-						value: -6
+						faderValue: -6
 					},{
 						mappingName: 'lawo_c2_fader',
-						value: -6
+						faderValue: -6
 					}]
 				}
 			},
@@ -482,7 +482,7 @@ describe('Lawo', () => {
 					deviceType: DeviceType.LAWO,
 					type: TimelineContentTypeLawo.SOURCE,
 
-					value: 0,
+					faderValue: 0,
 					overridePriority: 1
 				}
 			},
@@ -499,11 +499,11 @@ describe('Lawo', () => {
 
 					sources: [{
 						mappingName: 'lawo_c1_fader',
-						value: -4,
+						faderValue: -4,
 						transitionDuration: 400
 					},{
 						mappingName: 'lawo_c2_fader',
-						value: -4,
+						faderValue: -4,
 						transitionDuration: 400
 					}],
 					overridePriority: 1
@@ -520,7 +520,7 @@ describe('Lawo', () => {
 					deviceType: DeviceType.LAWO,
 					type: TimelineContentTypeLawo.SOURCE,
 
-					value: -12,
+					faderValue: -12,
 					transitionDuration: 400
 				}
 			}

--- a/src/devices/__tests__/lawo.spec.ts
+++ b/src/devices/__tests__/lawo.spec.ts
@@ -523,7 +523,7 @@ describe('Lawo', () => {
 					value: -12,
 					transitionDuration: 400
 				}
-			},
+			}
 		]
 
 		await mockTime.advanceTimeToTicks(10200)

--- a/src/devices/lawo.ts
+++ b/src/devices/lawo.ts
@@ -282,7 +282,7 @@ export class LawoDevice extends DeviceWithState<TimelineState> implements IDevic
 					type: TimelineContentTypeLawo.SOURCE,
 					key: 'fader',
 					identifier: identifier,
-					value: fader.value,
+					value: fader.faderValue,
 					valueType: EmberModel.ParameterType.Real,
 					transitionDuration: fader.transitionDuration,
 					priority: mapping.priority || 0,
@@ -314,10 +314,17 @@ export class LawoDevice extends DeviceWithState<TimelineState> implements IDevic
 				} else if (mapping.identifier && lawoObj.content.type === TimelineContentTypeLawo.SOURCE) {
 					// mapping is for a source
 					let tlObjectSource: TimelineObjLawoSource = lawoObj as TimelineObjLawoSource
+					let fader: ContentTimelineObjLawoSource = tlObjectSource.content
+					const priority = tlObjectSource.content.overridePriority
 					// TODO - next breaking change, remove deprecated tlObject typings "Fader/Motor dB Value"
-					const fader: ContentTimelineObjLawoSource = tlObjectSource.content['Fader/Motor dB Value'] || tlObjectSource.content
-					const priority = 'overridePriority' in tlObjectSource.content ? tlObjectSource.content.overridePriority : undefined
+					if ('Fader/Motor dB Value' in tlObjectSource.content) {
+						fader = {
+							faderValue: tlObjectSource.content['Fader/Motor dB Value'].value,
+							transitionDuration: tlObjectSource.content['Fader/Motor dB Value'].transitionDuration
+						}
+					}
 					pushFader(mapping.identifier, fader, mapping, tlObject.id, priority)
+
 				} else if (mapping.identifier && lawoObj.content.type === TimelineContentTypeLawo.EMBER_PROPERTY) {
 					// mapping is a property to set
 					let tlObjectSource: TimelineObjLawoEmberProperty = lawoObj as TimelineObjLawoEmberProperty

--- a/src/devices/lawo.ts
+++ b/src/devices/lawo.ts
@@ -19,7 +19,9 @@ import {
 	LawoCommand,
 	SetLawoValueFn,
 	LawoOptions,
-	LawoDeviceMode
+	LawoDeviceMode,
+	ContentTimelineObjLawoSource,
+	MappingLawoType
 } from '../types/src'
 import {
 	TimelineState, ResolvedTimelineObjectInstance
@@ -269,31 +271,55 @@ export class LawoDevice extends DeviceWithState<TimelineState> implements IDevic
 		const lawoState: LawoState = {
 			nodes: {}
 		}
+		const attrName = this._rampMotorFunctionPath || !this._dbPropertyName ? 'Fader.Motor dB Value' : this._dbPropertyName
+
+		const newFaders: Array<{ attrPath: string, node: LawoStateNode, priority: number }> = []
+		const pushFader = (identifier: string, fader: ContentTimelineObjLawoSource, mapping: MappingLawo, tlObjId: string, priority = 0) => {
+			newFaders.push({
+				attrPath: this._sourceNodeAttributePath(identifier, attrName),
+				priority,
+				node: {
+					type: TimelineContentTypeLawo.SOURCE,
+					key: 'fader',
+					identifier: identifier,
+					value: fader.value,
+					valueType: EmberModel.ParameterType.Real,
+					transitionDuration: fader.transitionDuration,
+					priority: mapping.priority || 0,
+					timelineObjId: tlObjId
+				}
+			})
+		}
 
 		_.each(state.layers, (tlObject: ResolvedTimelineObjectInstance, layerName: string) => {
+			// for every layer
 			const lawoObj = tlObject as any as TimelineObjLawoAny
 
 			const mapping: MappingLawo | undefined = this.getMapping()[layerName] as MappingLawo
+
 			if (mapping && mapping.device === DeviceType.LAWO) {
+				// Mapping is for Lawo
 
-				if (mapping.identifier && lawoObj.content.type === TimelineContentTypeLawo.SOURCE) {
-					let tlObjectSource: TimelineObjLawoSource = lawoObj as TimelineObjLawoSource
+				if (mapping.mappingType === MappingLawoType.SOURCES && lawoObj.content.type === TimelineContentTypeLawo.SOURCES) {
+					// mapping implies a composite of sources
+					for (const fader of lawoObj.content.sources) {
+						// for every mapping in the composite
+						const sourceMapping: MappingLawo | undefined = this.getMapping()[fader.mappingName] as MappingLawo
 
-					const fader: TimelineObjLawoSource['content']['Fader/Motor dB Value'] = tlObjectSource.content['Fader/Motor dB Value']
-					const attrName = this._rampMotorFunctionPath || !this._dbPropertyName ? 'Fader/Motor dB Value' : this._dbPropertyName
+						if (!sourceMapping || !sourceMapping.identifier || sourceMapping.mappingType !== MappingLawoType.SOURCE) continue
+						// mapped mapping is a source mapping
 
-					lawoState.nodes[this._sourceNodeAttributePath(mapping.identifier, attrName)] = {
-						type: tlObjectSource.content.type,
-						key: 'Fader/Motor dB Value',
-						identifier: mapping.identifier,
-						value: fader.value,
-						valueType: EmberModel.ParameterType.Real,
-						transitionDuration: fader.transitionDuration,
-						priority: mapping.priority || 0,
-						timelineObjId: tlObject.id
+						pushFader(sourceMapping.identifier, fader, sourceMapping, tlObject.id, lawoObj.content.overridePriority)
 					}
-
+				} else if (mapping.identifier && lawoObj.content.type === TimelineContentTypeLawo.SOURCE) {
+					// mapping is for a source
+					let tlObjectSource: TimelineObjLawoSource = lawoObj as TimelineObjLawoSource
+					// TODO - next breaking change, remove deprecated tlObject typings "Fader/Motor dB Value"
+					const fader: ContentTimelineObjLawoSource = tlObjectSource.content['Fader/Motor dB Value'] || tlObjectSource.content
+					const priority = 'overridePriority' in tlObjectSource.content ? tlObjectSource.content.overridePriority : undefined
+					pushFader(mapping.identifier, fader, mapping, tlObject.id, priority)
 				} else if (mapping.identifier && lawoObj.content.type === TimelineContentTypeLawo.EMBER_PROPERTY) {
+					// mapping is a property to set
 					let tlObjectSource: TimelineObjLawoEmberProperty = lawoObj as TimelineObjLawoEmberProperty
 
 					lawoState.nodes[mapping.identifier] = {
@@ -307,12 +333,21 @@ export class LawoDevice extends DeviceWithState<TimelineState> implements IDevic
 					}
 
 				} else if (lawoObj.content.type === TimelineContentTypeLawo.TRIGGER_VALUE) {
+					// mapping is a trigger value (will resend all commands to the Lawo to enforce state when changed)
 					let tlObjectSource: TimelineObjLawoEmberRetrigger = lawoObj as TimelineObjLawoEmberRetrigger
 
 					lawoState.triggerValue = tlObjectSource.content.triggerValue
 				}
 			}
+
 		})
+
+		newFaders.sort((a, b) => a.priority - b.priority)
+		// layers are sorted by priority
+		for (const newFader of newFaders) {
+			lawoState.nodes[newFader.attrPath] = newFader.node
+		}
+		// highest priority source has been written to lawoState
 
 		return lawoState
 	}
@@ -374,7 +409,7 @@ export class LawoDevice extends DeviceWithState<TimelineState> implements IDevic
 				_.omit(newNode, 'timelineObjId'),
 				_.omit(oldValue, 'timelineObjId')
 			)
-			if (diff || (newNode.key === 'Fader/Motor dB Value' && isRetrigger)) {
+			if (diff || (newNode.key === 'fader' && isRetrigger)) {
 				// It's a plain value:
 				commands.push({
 					cmd: {
@@ -422,7 +457,7 @@ export class LawoDevice extends DeviceWithState<TimelineState> implements IDevic
 		return _.compact([
 			this._sourcesPath,
 			identifier,
-			attributePath.replace('/', '.')
+			attributePath
 		]).join('.')
 	}
 
@@ -439,7 +474,7 @@ export class LawoDevice extends DeviceWithState<TimelineState> implements IDevic
 		this._lastSentValue[command.path] = startSend
 
 		try {
-			if (command.key === 'Fader/Motor dB Value' && command.transitionDuration && command.transitionDuration >= 0) {	// fader level
+			if (command.key === 'fader' && command.transitionDuration && command.transitionDuration >= 0) {	// fader level
 				// TODO - Lawo result 6 code is based on time - difference ratio, certain ratios we may want to run a manual fade?
 				if (!this._rampMotorFunctionPath || (command.transitionDuration < 500 && this._faderIntervalTime < 250)) {
 					// add the fade to the fade object, such that we can fade the signal using the fader

--- a/src/types/src/lawo.ts
+++ b/src/types/src/lawo.ts
@@ -71,7 +71,7 @@ export enum TimelineContentTypeLawo { //  Lawo-state
 export type TimelineObjLawoAny = TimelineObjLawoSources | TimelineObjLawoSource | TimelineObjLawoSourceDeprecated | TimelineObjLawoEmberProperty | TimelineObjLawoEmberRetrigger
 
 export interface ContentTimelineObjLawoSource {
-	value: number
+	faderValue: number
 	transitionDuration?: number
 }
 
@@ -98,7 +98,10 @@ export interface TimelineObjLawoSourceDeprecated extends TimelineObjLawoBase {
 		deviceType: DeviceType.LAWO
 		type: TimelineContentTypeLawo.SOURCE
 
-		'Fader/Motor dB Value': ContentTimelineObjLawoSource
+		'Fader/Motor dB Value': {
+			value: number
+			transitionDuration?: number
+		}
 	}
 }
 export interface TimelineObjLawoSource extends TimelineObjLawoBase {

--- a/src/types/src/lawo.ts
+++ b/src/types/src/lawo.ts
@@ -22,6 +22,7 @@ export interface MappingLawo extends Mapping {
 }
 export enum MappingLawoType {
 	SOURCE = 'source',
+	SOURCES = 'sources', // TODO - naming? can this also be a full path or trigger val?
 	FULL_PATH = 'fullpath',
 	TRIGGER_VALUE = 'triggerValue'
 }
@@ -62,11 +63,17 @@ export interface LawoCommand {
 
 export enum TimelineContentTypeLawo { //  Lawo-state
 	SOURCE = 'lawosource', // a general content type, possibly to be replaced by specific ones later?
+	SOURCES = 'lawosources',
 	EMBER_PROPERTY = 'lawofullpathemberproperty',
 	TRIGGER_VALUE = 'triggervalue'
 }
 
-export type TimelineObjLawoAny = TimelineObjLawoSource | TimelineObjLawoEmberProperty | TimelineObjLawoEmberRetrigger
+export type TimelineObjLawoAny = TimelineObjLawoSources | TimelineObjLawoSource | TimelineObjLawoSourceDeprecated | TimelineObjLawoEmberProperty | TimelineObjLawoEmberRetrigger
+
+export interface ContentTimelineObjLawoSource {
+	value: number
+	transitionDuration?: number
+}
 
 export interface TimelineObjLawoBase extends TSRTimelineObjBase {
 	content: {
@@ -74,16 +81,33 @@ export interface TimelineObjLawoBase extends TSRTimelineObjBase {
 		type: TimelineContentTypeLawo
 	}
 }
+export interface TimelineObjLawoSources extends TimelineObjLawoBase {
+	content: {
+		deviceType: DeviceType.LAWO
+		type: TimelineContentTypeLawo.SOURCES
+
+		sources: Array<{
+			mappingName: string
+		} & ContentTimelineObjLawoSource>
+		overridePriority?: number // defaults to 0
+	}
+}
+// TODO - remove this interface during the next breaking change:
+export interface TimelineObjLawoSourceDeprecated extends TimelineObjLawoBase {
+	content: {
+		deviceType: DeviceType.LAWO
+		type: TimelineContentTypeLawo.SOURCE
+
+		'Fader/Motor dB Value': ContentTimelineObjLawoSource
+	}
+}
 export interface TimelineObjLawoSource extends TimelineObjLawoBase {
 	content: {
 		deviceType: DeviceType.LAWO
 		type: TimelineContentTypeLawo.SOURCE
 
-		'Fader/Motor dB Value': {
-			value: number
-			transitionDuration?: number
-		}
-	}
+		overridePriority?: number // defaults to 0
+	} & ContentTimelineObjLawoSource
 }
 export interface TimelineObjLawoEmberProperty extends TimelineObjLawoBase {
 	content: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2185,10 +2185,10 @@ email-addresses@^3.0.1:
   resolved "https://registry.yarnpkg.com/email-addresses/-/email-addresses-3.1.0.tgz#cabf7e085cbdb63008a70319a74e6136188812fb"
   integrity sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg==
 
-emberplus-connection@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/emberplus-connection/-/emberplus-connection-0.0.2.tgz#191761640bdfce1a23a4f216d3dbaa9dfa1830e8"
-  integrity sha512-Kl19gJBKEhAaMKH8xx+Ezk85BKUFFtik36qmG/aigIq7SAs9NVPriDTuXdtnr4pFAuQB8OwylWwSrwIz+ktRIg==
+emberplus-connection@^0.0.3-nightly-20200622-114815-88534e2.0:
+  version "0.0.3-nightly-20200622-114815-88534e2.0"
+  resolved "https://registry.yarnpkg.com/emberplus-connection/-/emberplus-connection-0.0.3-nightly-20200622-114815-88534e2.0.tgz#32682f6a9d7bb189f154857c021d8fa7132b3bd3"
+  integrity sha512-0SkeCLmcIuPN5GZIxmlmAETpxlsrCx+hNSwlpBErOcq4v7Vr8rRKdpc9lWC0eJ4WtdkKr18oj0bdy5nHG101dg==
   dependencies:
     asn1 evs-broadcast/node-asn1
     enum "^2.4.0"


### PR DESCRIPTION
This PR gives the timeline author the ability to define the fader value for multiple Lawo-sources in a single object

Similar to https://github.com/nrkno/tv-automation-state-timeline-resolver/pull/151

In addition it removes the `Fader/Motor dB Value` object in favour of a flat structure

Example timeline object for composites:
```ts
{
	id: 'obj0',
	enable: {
		while: 1
	},
	layer: 'lawo_base',
	content: {
		deviceType: DeviceType.LAWO,
		type: TimelineContentTypeLawo.SOURCES,

		sources: [{
			mappingName: 'lawo_c1_fader',
			value: -6
		},{
			mappingName: 'lawo_c2_fader',
			value: -6
		}]
	}
}
```

New timeline object content structure
```ts
{
	deviceType: DeviceType.LAWO,
	type: TimelineContentTypeLawo.SOURCE,

	faderValue: -6,
	transitionDuration: 750
}
```