### PR TITLE
Timeline upgrade + partial resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "@types/sprintf-js": "^1.1.0",
     "@types/underscore": "^1.9.2",
     "@types/ws": "^7.2.4",
+    "@types/xml-js": "^1.0.0",
     "codecov": "^3.6.1",
     "gh-pages": "^3.0.0",
     "jest": "^26.0.1",
@@ -155,10 +156,6 @@
     "yargs-parser": "^18.1.2"
   },
   "dependencies": {
-    "@types/request": "^2.48.1",
-    "@types/sprintf-js": "^1.1.0",
-    "@types/ws": "^6.0.1",
-    "@types/xml-js": "^1.0.0",
     "atem-connection": "1.1.0",
     "atem-state": "^0.9.0",
     "casparcg-connection": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "p-timeout": "^3.2.0",
     "request": "^2.88.0",
     "sprintf-js": "^1.1.2",
-    "superfly-timeline": "^7.3.1",
+    "superfly-timeline": "^8.1.0",
     "threadedclass": "^0.7.0",
     "tslib": "^1.10.0",
     "tv-automation-quantel-gateway-client": "^1.0.8",

--- a/src/AsyncResolver.ts
+++ b/src/AsyncResolver.ts
@@ -55,16 +55,18 @@ export class AsyncResolver {
 		const timeLineMap: {[id: string]: TSRTimelineObj} = {}
 
 		let setObjectTime = (o: TSRTimelineObj, time: number) => {
-			o.enable.start = time // set the objects to "now" so that they are resolved correctly temporarily
-			const o2 = timeLineMap[o.id]
-			if (o2) {
-				o2.enable.start = time
-			}
+			if (!_.isArray(o.enable)) {
+				o.enable.start = time // set the objects to "now" so that they are resolved correctly temporarily
+				const o2 = timeLineMap[o.id]
+				if (o2 && !_.isArray(o2.enable)) {
+					o2.enable.start = time
+				}
 
-			objectsFixed.push({
-				id: o.id,
-				time: time
-			})
+				objectsFixed.push({
+					id: o.id,
+					time: time
+				})
+			}
 		}
 
 		_.each(timeline, (obj) => {
@@ -73,8 +75,10 @@ export class AsyncResolver {
 
 		// First: fix the ones on the first level (i e not in groups), because they are easy (this also saves us one iteration time later):
 		_.each(timeLineMap, (o: TSRTimelineObj) => {
-			if (o.enable.start === 'now') {
-				setObjectTime(o, now)
+			if (!_.isArray(o.enable)) {
+				if (o.enable.start === 'now') {
+					setObjectTime(o, now)
+				}
 			}
 		})
 
@@ -87,6 +91,7 @@ export class AsyncResolver {
 
 			_.each(objs, (o: TSRTimelineObj) => {
 				if (
+					!_.isArray(o.enable) &&
 					o.enable.start === 'now'
 				) {
 					// find parent, and set relative to that

--- a/src/AsyncResolver.ts
+++ b/src/AsyncResolver.ts
@@ -3,7 +3,8 @@ import {
 	TimelineObject,
 	ResolvedTimeline,
 	ResolvedTimelineObject,
-	ResolvedStates
+	ResolvedStates,
+	ResolverCache
 } from 'superfly-timeline'
 import _ = require('underscore')
 import {
@@ -15,6 +16,8 @@ export class AsyncResolver {
 
 	private readonly onSetTimelineTriggerTime: (res: TimelineTriggerTimeResult) => void
 
+	private cache: ResolverCache = {}
+
 	public constructor (onSetTimelineTriggerTime: (res: TimelineTriggerTimeResult) => void) {
 		this.onSetTimelineTriggerTime = onSetTimelineTriggerTime
 	}
@@ -22,7 +25,8 @@ export class AsyncResolver {
 	public async resolveTimeline (
 		resolveTime: number,
 		timeline: TSRTimeline,
-		limitTime: number
+		limitTime: number,
+		useCache: boolean
 	) {
 
 		let objectsFixed = this._fixNowObjects(timeline, resolveTime)
@@ -30,7 +34,8 @@ export class AsyncResolver {
 		const resolvedTimeline = Resolver.resolveTimeline(timeline, {
 			limitCount: 999,
 			limitTime: limitTime,
-			time: resolveTime
+			time: resolveTime,
+			cache: useCache ? this.cache : undefined
 		})
 
 		const resolvedStates = Resolver.resolveAllStates(resolvedTimeline)

--- a/src/__tests__/conductor.spec.ts
+++ b/src/__tests__/conductor.spec.ts
@@ -182,6 +182,7 @@ describe('Conductor', () => {
 			'myLayer0': myLayerMapping1,
 			'myLayer1': myLayerMapping0
 		})
+		if (_.isArray(abstractThing0.enable)) throw new Error('.enable should not be an array')
 		abstractThing0.enable.start = mockTime.now
 		conductor.timeline = [ abstractThing0 ]
 	})
@@ -252,6 +253,7 @@ describe('Conductor', () => {
 			_.each(results, (trigger) => {
 				let o = _.findWhere(timeline, { id: trigger.id })
 				if (o) {
+					if (_.isArray(o.enable)) throw new Error('.enable should not be an array')
 					o.enable.start = trigger.time
 				}
 			})

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -724,9 +724,15 @@ export class Conductor extends EventEmitter {
 
 				// Apply changes to fixed objects (set "now" triggers to an actual time):
 				// This gets persisted on this.timeline, so we only have to do this once
-				const nowIds: {[id: string]: number} = {}
-				_.each(o.objectsFixed, (o) => nowIds[o.id] = o.time)
-				const fixNow = (o: TimelineObject) => { if (nowIds[o.id]) o.enable.start = nowIds[o.id] }
+				const nowIdsTime: {[id: string]: number} = {}
+				_.each(o.objectsFixed, (o) => nowIdsTime[o.id] = o.time)
+				const fixNow = (o: TimelineObject) => {
+					if (nowIdsTime[o.id]) {
+						if (!_.isArray(o.enable)) {
+							o.enable.start = nowIdsTime[o.id]
+						}
+					}
+				}
 				_.each(timeline, (o) => applyRecursively(o, fixNow))
 
 			}

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -39,6 +39,7 @@ import { VizMSEDevice, DeviceOptionsVizMSEInternal } from './devices/vizMSE'
 import PQueue from 'p-queue'
 import * as PAll from 'p-all'
 import PTimeout from 'p-timeout'
+
 export { DeviceContainer }
 export { CommandWithContext }
 
@@ -65,6 +66,7 @@ export interface ConductorOptions {
 	getCurrentTime?: () => number
 	autoInit?: boolean
 	multiThreadedResolver?: boolean
+	useCacheWhenResolving?: boolean
 	proActiveResolve?: boolean
 }
 interface TimelineCallback {
@@ -132,6 +134,7 @@ export class Conductor extends EventEmitter {
 	private _isInitialized: boolean = false
 	private _doOnTime: DoOnTime
 	private _multiThreadedResolver: boolean = false
+	private _useCacheWhenResolving: boolean = false
 
 	private _callbackInstances: {[instanceId: number]: CallbackInstance} = {}
 	private _triggerSendStartStopCallbacksTimeout: NodeJS.Timer | null = null
@@ -158,6 +161,7 @@ export class Conductor extends EventEmitter {
 		this._options = options
 
 		this._multiThreadedResolver = !!options.multiThreadedResolver
+		this._useCacheWhenResolving = !!options.useCacheWhenResolving
 
 		if (options.getCurrentTime) this._getCurrentTime = options.getCurrentTime
 
@@ -715,7 +719,8 @@ export class Conductor extends EventEmitter {
 				let o = await this._resolver.resolveTimeline(
 					resolveTime,
 					timeline,
-					resolveTime + RESOLVE_LIMIT_TIME
+					resolveTime + RESOLVE_LIMIT_TIME,
+					this._useCacheWhenResolving
 				)
 				resolvedStates = o.resolvedStates
 

--- a/src/devices/__tests__/atem.spec.ts
+++ b/src/devices/__tests__/atem.spec.ts
@@ -281,7 +281,8 @@ describe('Atem', () => {
 			resolved: {
 				resolved: true,
 				resolving: false,
-				instances: [{ start: mockTime.now - 1000, end: Infinity, id: 'a0', references: [] }]
+				instances: [{ start: mockTime.now - 1000, end: Infinity, id: 'a0', references: [] }],
+				directReferences: []
 			},
 			instance: { start: mockTime.now - 1000, end: Infinity, id: 'a0', references: [] }
 		}

--- a/src/types/package.json
+++ b/src/types/package.json
@@ -84,7 +84,7 @@
 		"node-license-validator": "^1.3.0",
 		"npm-scripts-info": "^0.3.9",
 		"open-cli": "^6.0.1",
-		"superfly-timeline": "^7.1.2",
+		"superfly-timeline": "^8.1.0",
 		"trash-cli": "^3.0.0",
 		"tslint": "^6.1.2",
 		"tslint-config-standard": "^9.0.0",

--- a/src/types/src/superfly-timeline.ts
+++ b/src/types/src/superfly-timeline.ts
@@ -102,6 +102,8 @@ export interface ResolvedTimeline {
 		resolvedGroupCount: number
 		/** Number of resolved keyframes */
 		resolvedKeyframeCount: number
+		/** How many objects that was actually resolved (is affected when using cache) */
+		resolvingCount: number
 	}
 }
 export interface ResolvedTimelineObjects {
@@ -121,6 +123,10 @@ export interface ResolvedTimelineObject extends TimelineObject {
 		parentId?: string
 		/** True if object is a keyframe */
 		isKeyframe?: boolean
+		/** True if object is referencing itself (only directly, not indirectly via another object) */
+		isSelfReferencing?: boolean
+		/** Ids of all other objects that directly affects this object (ie through direct reference, classes, etc) */
+		directReferences: string[]
 	}
 }
 export interface TimelineObjectInstance {

--- a/src/types/src/superfly-timeline.ts
+++ b/src/types/src/superfly-timeline.ts
@@ -29,7 +29,7 @@ export interface ResolveOptions {
 }
 export interface TimelineObject {
 	id: ObjectId
-	enable: TimelineEnable
+	enable: TimelineEnable | TimelineEnable[]
 	layer: string | number
 	/** Group children */
 	children?: Array<TimelineObject>
@@ -68,7 +68,7 @@ export interface TimelineEnable {
 }
 export interface TimelineKeyframe {
 	id: string
-	enable: TimelineEnable
+	enable: TimelineEnable | TimelineEnable[]
 	duration?: number | string
 	classes?: Array<string>
 	content: Content

--- a/src/types/yarn.lock
+++ b/src/types/yarn.lock
@@ -1828,12 +1828,12 @@ strtok3@^6.0.0:
     debug "^4.1.1"
     peek-readable "^3.1.0"
 
-superfly-timeline@^7.1.2:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/superfly-timeline/-/superfly-timeline-7.3.1.tgz#6a7aa04a768be198c677ad8a1e8eacdfc603c8fb"
-  integrity sha512-xmg9GgVNWUPA48MGwrwicwP/yEw7gZSl5nVnwcf3p50GZx1ChOxa5rCJQyTpPoyKG8pqwXKZkbJsq2ylk2p4iQ==
+superfly-timeline@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/superfly-timeline/-/superfly-timeline-8.1.0.tgz#40666fc1a1f65d7df5184046be5b1f626154c64e"
+  integrity sha512-Bt8QZdz30khJ+dka6fBgfVPptx2iVW/qbNuaePs3iNO0B+vP8lsjt4Fq+yIhSWldSRfI3trwDXN8UYpQ1jDy/w==
   dependencies:
-    tslib "^1.10.0"
+    tslib "^1.13.0"
     underscore "^1.9.1"
 
 supports-color@^5.3.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6253,12 +6253,12 @@ stubs@^3.0.0:
   resolved "https://registry.yarnpkg.com/stubs/-/stubs-3.0.0.tgz#e8d2ba1fa9c90570303c030b6900f7d5f89abe5b"
   integrity sha1-6NK6H6nJBXAwPAMLaQD31fiavls=
 
-superfly-timeline@^7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/superfly-timeline/-/superfly-timeline-7.3.1.tgz#6a7aa04a768be198c677ad8a1e8eacdfc603c8fb"
-  integrity sha512-xmg9GgVNWUPA48MGwrwicwP/yEw7gZSl5nVnwcf3p50GZx1ChOxa5rCJQyTpPoyKG8pqwXKZkbJsq2ylk2p4iQ==
+superfly-timeline@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/superfly-timeline/-/superfly-timeline-8.1.0.tgz#40666fc1a1f65d7df5184046be5b1f626154c64e"
+  integrity sha512-Bt8QZdz30khJ+dka6fBgfVPptx2iVW/qbNuaePs3iNO0B+vP8lsjt4Fq+yIhSWldSRfI3trwDXN8UYpQ1jDy/w==
   dependencies:
-    tslib "^1.10.0"
+    tslib "^1.13.0"
     underscore "^1.9.1"
 
 supports-color@^5.3.0:
@@ -6554,7 +6554,7 @@ tslib@1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
   integrity sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.2:
+tslib@^1.10.0, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.2:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,10 +777,10 @@
   resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.10.0.tgz#5cb0dff2a5f616fc8e0c61b482bf01fa20a03cec"
   integrity sha512-ZAbqul7QAKpM2h1PFGa5ETN27ulmqtj0QviYHasw9LffvXZvVHuraOx/FOsIPPDNGZN0Qo1nASxxSfMYOtSoCw==
 
-"@types/ws@^6.0.1":
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-6.0.4.tgz#7797707c8acce8f76d8c34b370d4645b70421ff1"
-  integrity sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==
+"@types/ws@^7.2.4":
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.2.6.tgz#516cbfb818310f87b43940460e065eb912a4178d"
+  integrity sha512-Q07IrQUSNpr+cXU4E4LtkSIBPie5GLZyyMC1QtQYRLWz701+XcoVygGUZgvLqElq1nU4ICldMYPnexlBsg3dqQ==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
This PR updates the timeline dependency to the latest and adds a config option (`useCacheWhenResolving`) to use the new timeline-resolve feature for using a cache to do partial resolves (improves performance when only small changes are made in the timeline)