### PR TITLE
feat: Add External Elements status reporting to Viz device

### DIFF
--- a/src/devices/device.ts
+++ b/src/devices/device.ts
@@ -8,6 +8,7 @@ import {
 import { EventEmitter } from 'events'
 import { CommandReport, DoOnTime } from '../doOnTime'
 import { DeviceInitOptions, DeviceOptionsAny } from '../types/src/device'
+import { MediaObject } from '../types/src/mediaObject'
 /*
 	This is a base class for all the Device wrappers.
 	The Device wrappers will
@@ -240,7 +241,11 @@ export abstract class Device extends EventEmitter implements IDevice {
 		/** A report that a command was sent too late */
 		((event: 'slowCommand',			listener: (commandInfo: string) => void) => this) &
 		/** Something went wrong when executing a command  */
-		((event: 'commandError', 		listener: (error: Error, context: CommandWithContext) => void) => this)
+		((event: 'commandError', 		listener: (error: Error, context: CommandWithContext) => void) => this) &
+		/** Update a MediaObject  */
+		((event: 'updateMediaObject',	listener: (collectionId: string, docId: string, doc: MediaObject | null) => void) => this) &
+		/** Clear a MediaObjects collection */
+		((event: 'clearMediaObjects',	listener: (collectionId: string) => void) => this)
 
 		// Overide EventEmitter.emit() for stronger typings:
 	emit: ((event: 'info',				info: string) => boolean) &
@@ -251,7 +256,9 @@ export abstract class Device extends EventEmitter implements IDevice {
 		((event: 'resetResolver') => boolean) &
 		((event: 'slowCommand',			commandInfo: string) => boolean) &
 		((event: 'commandReport',		commandReport: CommandReport) => boolean) &
-		((event: 'commandError',		error: Error, context: CommandWithContext) => boolean)
+		((event: 'commandError',		error: Error, context: CommandWithContext) => boolean) &
+		((event: 'updateMediaObject',	collectionId: string, docId: string, doc: MediaObject | null) => boolean) &
+		((event: 'clearMediaObjects',	collectionId: string) => boolean)
 
 	public get instanceId (): number {
 		return this._instanceId

--- a/src/types/src/index.ts
+++ b/src/types/src/index.ts
@@ -39,6 +39,7 @@ import { TimelineObjVMixAny } from './vmix'
 export { Timeline }
 export * from './mapping'
 export * from './expectedPlayoutItems'
+export * from './mediaObject'
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 

--- a/src/types/src/mediaObject.ts
+++ b/src/types/src/mediaObject.ts
@@ -1,0 +1,35 @@
+export interface MediaInfo {
+	name: string
+}
+
+export interface MediaObject {
+	/** The playable reference (CasparCG clip name, quantel GUID, etc) */
+	mediaId: string
+
+	/** Media object file path relative to playout server */
+	mediaPath: string
+	/** Media object size in bytes */
+	mediaSize: number
+	/** Timestamp when the media object was last updated */
+	mediaTime: number
+	/** Info about media content. If undefined: inficates that the media is NOT playable (could be transferring, or a placeholder)  */
+	mediainfo?: MediaInfo
+
+	/** Thumbnail file size in bytes */
+	thumbSize: number
+	/** Thumbnail last updated timestamp */
+	thumbTime: number
+
+	/** Preview file size in bytes */
+	previewSize?: number
+	/** Thumbnail last updated timestamp */
+	previewTime?: number
+	/** Preview location */
+	previewPath?: string
+
+	cinf: string // useless to us
+	tinf: string // useless to us
+
+	_id: string
+	_rev: string
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds reporting of loading status of External Elements (Pilot) in Viz device, by creating/removing Media Objects in core's collection. 

* **What is the current behavior?** (You can also link to an open issue here)
No way to report if an Element was loaded or not.


* **What is the new behavior (if this is a feature change)?**
New `updateMediaObject` and `clearMediaObjects` events, that have to be handled by the Playout Gateway, are added.
A Media Object is created for every External Elements that is loaded. 
Media objects created by this device have their `collectionId` set to the Id of the device. This collection is cleared on activation and deactivation.

* **Other information**:
