### PR TITLE
BREAKING: Treat Mappings as dynamic data

### DIFF
--- a/examples/CasparcgVideoPlayES6example.js
+++ b/examples/CasparcgVideoPlayES6example.js
@@ -52,11 +52,11 @@ tsrConductor.init()
 
 			// playing: false, // Set to true to pause the clip
 			// pauseTime: Date.now() // the time at which the clip was paused
-		} 
+		}
 	});
 	console.log('set timeline');
-	tsrConductor.timeline = [
+	tsrConductor.setTimelineAndMappings([
 		video0
-	];
+	]);
 	// After the timeline has been set, the TSR Conductor will make sure it starts playing
 });

--- a/examples/playVideoInCaspar.ts
+++ b/examples/playVideoInCaspar.ts
@@ -26,14 +26,14 @@ let a = async function () {
 	})
 
 	// Setup mappings from layers to outputs:
-	tsr.setMapping({
+	const mappings = {
 		'layer0': {
 			device: DeviceType.CASPARCG,
 			deviceId: 'casparcg0',
 			channel: 1,
 			layer: 10
 		}
-	})
+	}
 	// Set a new timeline:
 	let video0: TSRTimelineObj = {
 		id: 'video0',
@@ -54,9 +54,9 @@ let a = async function () {
 		}
 	}
 	console.log('set timeline')
-	tsr.timeline = [
+	tsr.setTimelineAndMappings([
 		video0
-	]
+	], mappings)
 
 }
 a().catch(e => console.log(e))

--- a/examples/testChangeTimelineQuickly.ts
+++ b/examples/testChangeTimelineQuickly.ts
@@ -25,18 +25,18 @@ let a = async function () {
 	})
 
 	// Setup mappings from layers to outputs:
-	tsr.setMapping({
+	const mappings = {
 		'layer0': {
 			device: DeviceType.CASPARCG,
 			deviceId: 'casparcg0',
 			channel: 1,
 			layer: 10
 		}
-	})
+	}
 
 	setTimeout(() => {
 		console.log('set timeline')
-		tsr.timeline = [
+		tsr.setTimelineAndMappings([
 			{
 				id: 'video0',
 				enable: {
@@ -53,10 +53,10 @@ let a = async function () {
 
 				}
 			}
-		]
+		], mappings)
 		setTimeout(() => {
 			console.log('set timeline')
-			tsr.timeline = [
+			tsr.setTimelineAndMappings([
 				{
 					id: 'video0',
 					enable: {
@@ -87,7 +87,7 @@ let a = async function () {
 						loop: true
 					}
 				}
-			]
+			])
 		}, 100)
 	}, 1000)
 	/*

--- a/src/__tests__/rundown.spec.ts
+++ b/src/__tests__/rundown.spec.ts
@@ -81,7 +81,6 @@ describe('Rundown', () => {
 				retryInterval: false
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 		await mockTime.advanceTimeToTicks(10001)
 
 		let deviceContainer = myConductor.getDevice('myCCG')
@@ -105,7 +104,7 @@ describe('Rundown', () => {
 		// 00:05 - pgm - stinger
 		// 00:05 - aux - bg_item2
 		// 00:08 - pgm - full opener
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'cam1',
 				content: {
@@ -339,7 +338,7 @@ describe('Rundown', () => {
 				},
 				layer: 'gfx'
 			}
-		]
+		], myLayerMapping)
 		await mockTime.advanceTimeToTicks(10101)
 
 		expect(mockTime.getCurrentTime()).toEqual(10101)

--- a/src/devices/__tests__/abstract.spec.ts
+++ b/src/devices/__tests__/abstract.spec.ts
@@ -42,7 +42,6 @@ describe('Abstract device', () => {
 				commandReceiver: commandReceiver0
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
 		let deviceContainer = myConductor.getDevice('myAbstract')
@@ -62,7 +61,7 @@ describe('Abstract device', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -87,7 +86,7 @@ describe('Abstract device', () => {
 					tmp0: 'abcde'
 				}
 			}
-		]
+		], myLayerMapping)
 
 		await mockTime.advanceTimeToTicks(10200)
 		expect(commandReceiver0).toHaveBeenCalledTimes(1)
@@ -153,7 +152,6 @@ describe('Abstract device', () => {
 			type: DeviceType.ABSTRACT,
 			options: {}
 		})
-		await myConductor.setMapping(myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
 		let deviceContainer = myConductor.getDevice('myAbstract')
@@ -168,7 +166,7 @@ describe('Abstract device', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -180,7 +178,7 @@ describe('Abstract device', () => {
 					deviceType: DeviceType.ABSTRACT
 				}
 			}
-		]
+		], myLayerMapping)
 
 		await mockTime.advanceTimeToTicks(10200)
 		expect(onDebug).toHaveBeenCalledTimes(1)

--- a/src/devices/__tests__/atem.spec.ts
+++ b/src/devices/__tests__/atem.spec.ts
@@ -54,7 +54,7 @@ describe('Atem', () => {
 			host: '127.0.0.1'
 		}))
 
-		device.handleState(mockState)
+		device.handleState(mockState, {})
 
 		device.queue.forEach((cmd) => {
 			console.log(cmd)
@@ -90,7 +90,7 @@ describe('Atem', () => {
 				port: 9910
 			}
 		}))
-		await myConductor.setMapping(myLayerMapping)
+
 		await mockTime.advanceTimeToTicks(10100)
 
 		let deviceContainer = myConductor.getDevice('myAtem')
@@ -99,7 +99,7 @@ describe('Atem', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -132,7 +132,7 @@ describe('Atem', () => {
 					}
 				}
 			}
-		]
+		], myLayerMapping)
 
 		commandReceiver0.mockClear()
 		await mockTime.advanceTimeToTicks(10200)
@@ -177,14 +177,13 @@ describe('Atem', () => {
 			}
 		}))
 
-		await myConductor.setMapping(myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
 		let deviceContainer = myConductor.getDevice('myAtem')
 		let device = deviceContainer.device as ThreadedClass<AtemDevice>
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -211,7 +210,7 @@ describe('Atem', () => {
 					}
 				}
 			}
-		]
+		], myLayerMapping)
 
 		await mockTime.advanceTimeToTicks(10200)
 
@@ -275,7 +274,6 @@ describe('Atem', () => {
 				host: '127.0.0.1'
 			}
 		}, mockTime.getCurrentTime)
-		device.setMapping(myLayerMapping)
 
 		await device.init(literal<AtemOptions>({
 			host: '127.0.0.1'
@@ -286,12 +284,12 @@ describe('Atem', () => {
 		expect(commandReceiver0).toHaveBeenCalledTimes(0)
 
 		// Expect that a command has been scheduled
-		device.handleState(mockState)
+		device.handleState(mockState, myLayerMapping)
 		expect(device.queue).toHaveLength(2)
 
 		// Handle the same state, before the commands have been sent
 		mockTime.advanceTimeTo(mockTime.now + 30)
-		device.handleState(mockState)
+		device.handleState(mockState, myLayerMapping)
 		expect(commandReceiver0).toHaveBeenCalledTimes(0)
 		expect(device.queue).toHaveLength(2)
 
@@ -300,7 +298,7 @@ describe('Atem', () => {
 		expect(commandReceiver0).toHaveBeenCalledTimes(2)
 
 		// Handle the same state, after the commands have been sent
-		device.handleState(mockState)
+		device.handleState(mockState, myLayerMapping)
 		expect(device.queue).toHaveLength(0)
 	})
 })

--- a/src/devices/__tests__/casparcg.spec.ts
+++ b/src/devices/__tests__/casparcg.spec.ts
@@ -7,7 +7,8 @@ import {
 	ChannelFormat,
 	Transition,
 	Ease,
-	Direction
+	Direction,
+	TSRTimeline
 } from '../../types/src'
 import { MockTime } from '../../__tests__/mockTime'
 import { getMockCall } from '../../__tests__/lib'
@@ -56,7 +57,6 @@ describe('CasparCG', () => {
 				useScheduling: true
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
 		expect(commandReceiver0).toHaveBeenCalledTimes(3)
@@ -73,7 +73,7 @@ describe('CasparCG', () => {
 		// Check that no commands has been scheduled:
 		expect(await device['queue']).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -89,7 +89,7 @@ describe('CasparCG', () => {
 					loop: true
 				}
 			}
-		]
+		], myLayerMapping)
 
 		await mockTime.advanceTimeToTicks(10200)
 
@@ -142,7 +142,6 @@ describe('CasparCG', () => {
 				useScheduling: true
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
 		expect(commandReceiver0).toHaveBeenCalledTimes(3)
@@ -159,7 +158,7 @@ describe('CasparCG', () => {
 		// Check that no commands has been scheduled:
 		expect(await device['queue']).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -174,7 +173,7 @@ describe('CasparCG', () => {
 					file: 'AMB'
 				}
 			}
-		]
+		], myLayerMapping)
 
 		await mockTime.advanceTimeToTicks(10200)
 
@@ -217,14 +216,13 @@ describe('CasparCG', () => {
 				useScheduling: false
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 
 		let deviceContainer = myConductor.getDevice('myCCG')
 		let device = deviceContainer.device
 
 		// Check that no commands has been scheduled:
 		expect(await device['queue']).toHaveLength(0)
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -239,7 +237,7 @@ describe('CasparCG', () => {
 					uri: 'rtsp://127.0.0.1:5004'
 				}
 			}
-		]
+		], myLayerMapping)
 		await mockTime.advanceTimeTicks(100)
 
 		// one command has been sent:
@@ -291,7 +289,6 @@ describe('CasparCG', () => {
 				useScheduling: true
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 
 		let deviceContainer = myConductor.getDevice('myCCG')
 		let device = deviceContainer.device
@@ -310,7 +307,7 @@ describe('CasparCG', () => {
 		expect(getMockCall(commandReceiver0, 1, 1).name).toEqual('TimeCommand')
 		expect(getMockCall(commandReceiver0, 2, 1).name).toEqual('TimeCommand')
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -327,7 +324,7 @@ describe('CasparCG', () => {
 					deviceFormat: ChannelFormat.HD_720P5000
 				}
 			}
-		]
+		], myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
 		// one command has been sent:
@@ -380,7 +377,6 @@ describe('CasparCG', () => {
 				useScheduling: true
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 
 		let deviceContainer = myConductor.getDevice('myCCG')
 		let device = deviceContainer.device
@@ -394,7 +390,7 @@ describe('CasparCG', () => {
 		expect(getMockCall(commandReceiver0, 1, 1).name).toEqual('TimeCommand')
 		expect(getMockCall(commandReceiver0, 2, 1).name).toEqual('TimeCommand')
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -414,7 +410,7 @@ describe('CasparCG', () => {
 					useStopCommand: true
 				}
 			}
-		]
+		], myLayerMapping)
 
 		await mockTime.advanceTimeToTicks(10100)
 
@@ -465,7 +461,6 @@ describe('CasparCG', () => {
 				useScheduling: true
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 
 		let deviceContainer = myConductor.getDevice('myCCG')
 		let device = deviceContainer.device
@@ -479,7 +474,7 @@ describe('CasparCG', () => {
 		expect(getMockCall(commandReceiver0, 1, 1).name).toEqual('TimeCommand')
 		expect(getMockCall(commandReceiver0, 2, 1).name).toEqual('TimeCommand')
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -495,7 +490,7 @@ describe('CasparCG', () => {
 					encoderOptions: '-format mkv -c:v libx264 -crf 22'
 				}
 			}
-		]
+		], myLayerMapping)
 
 		await mockTime.advanceTimeToTicks(10100)
 
@@ -551,7 +546,6 @@ describe('CasparCG', () => {
 				useScheduling: true
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 
 		let deviceContainer = myConductor.getDevice('myCCG')
 		let device = deviceContainer.device
@@ -566,7 +560,7 @@ describe('CasparCG', () => {
 		expect(getMockCall(commandReceiver0, 1, 1).name).toEqual('TimeCommand')
 		expect(getMockCall(commandReceiver0, 2, 1).name).toEqual('TimeCommand')
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -599,7 +593,7 @@ describe('CasparCG', () => {
 					delay: 320 * 1000
 				}
 			}
-		]
+		], myLayerMapping)
 
 		await mockTime.advanceTimeToTicks(10100)
 
@@ -666,7 +660,6 @@ describe('CasparCG', () => {
 				useScheduling: true
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 
 		// Check that no commands has been sent:
 		expect(commandReceiver0).toHaveBeenCalledTimes(0)
@@ -677,7 +670,7 @@ describe('CasparCG', () => {
 		expect(getMockCall(commandReceiver0, 1, 1).name).toEqual('TimeCommand')
 		expect(getMockCall(commandReceiver0, 2, 1).name).toEqual('TimeCommand')
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -707,7 +700,7 @@ describe('CasparCG', () => {
 					}
 				}
 			}
-		]
+		], myLayerMapping)
 
 		// fast-forward:
 		await mockTime.advanceTimeTicks(100)
@@ -774,12 +767,11 @@ describe('CasparCG', () => {
 				useScheduling: true
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 
 		// Check that no commands has been sent:
 		expect(commandReceiver0).toHaveBeenCalledTimes(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -837,7 +829,7 @@ describe('CasparCG', () => {
 					}
 				}]
 			}
-		]
+		], myLayerMapping)
 
 		// fast-forward:
 		await mockTime.advanceTimeTicks(100)
@@ -911,7 +903,6 @@ describe('CasparCG', () => {
 				useScheduling: true
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 
@@ -921,7 +912,7 @@ describe('CasparCG', () => {
 		expect(getMockCall(commandReceiver0, 1, 1).name).toEqual('TimeCommand')
 		expect(getMockCall(commandReceiver0, 2, 1).name).toEqual('TimeCommand')
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0_bg',
 				enable: {
@@ -954,7 +945,7 @@ describe('CasparCG', () => {
 					loop: true
 				}
 			}
-		]
+		], myLayerMapping)
 
 		await mockTime.advanceTimeTicks(100)
 		expect(commandReceiver0).toHaveBeenCalledTimes(5)
@@ -1020,7 +1011,6 @@ describe('CasparCG', () => {
 				useScheduling: true
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 
@@ -1030,7 +1020,7 @@ describe('CasparCG', () => {
 		expect(getMockCall(commandReceiver0, 1, 1).name).toEqual('TimeCommand')
 		expect(getMockCall(commandReceiver0, 2, 1).name).toEqual('TimeCommand')
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0_bg',
 				enable: {
@@ -1063,7 +1053,7 @@ describe('CasparCG', () => {
 					loop: true
 				}
 			}
-		]
+		], myLayerMapping)
 
 		await mockTime.advanceTimeTicks(100)
 		expect(commandReceiver0).toHaveBeenCalledTimes(5)
@@ -1127,7 +1117,6 @@ describe('CasparCG', () => {
 				useScheduling: true
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 
 		await mockTime.advanceTimeToTicks(10050)
 		expect(commandReceiver0).toHaveBeenCalledTimes(3)
@@ -1135,7 +1124,7 @@ describe('CasparCG', () => {
 		expect(getMockCall(commandReceiver0, 1, 1).name).toEqual('TimeCommand')
 		expect(getMockCall(commandReceiver0, 2, 1).name).toEqual('TimeCommand')
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0_bg',
 				enable: {
@@ -1168,7 +1157,7 @@ describe('CasparCG', () => {
 					loop: true
 				}
 			}
-		]
+		], myLayerMapping)
 
 		await mockTime.advanceTimeToTicks(10100)
 		expect(commandReceiver0).toHaveBeenCalledTimes(5)
@@ -1195,7 +1184,7 @@ describe('CasparCG', () => {
 		let tokenPlay = getMockCall(commandReceiver0, 4, 1)._objectParams.token
 
 		// then change my mind:
-		myConductor.timeline = []
+		myConductor.setTimelineAndMappings([])
 		await mockTime.advanceTimeToTicks(10200)
 
 		expect(commandReceiver0).toHaveBeenCalledTimes(7)
@@ -1242,7 +1231,6 @@ describe('CasparCG', () => {
 				useScheduling: true
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 
 		await mockTime.advanceTimeToTicks(10050)
 		expect(commandReceiver0).toHaveBeenCalledTimes(3)
@@ -1250,7 +1238,7 @@ describe('CasparCG', () => {
 		expect(getMockCall(commandReceiver0, 1, 1).name).toEqual('TimeCommand')
 		expect(getMockCall(commandReceiver0, 2, 1).name).toEqual('TimeCommand')
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -1281,7 +1269,7 @@ describe('CasparCG', () => {
 					loop: true
 				}
 			}
-		]
+		], myLayerMapping)
 
 		await mockTime.advanceTimeToTicks(30000)
 		expect(commandReceiver0).toHaveBeenCalledTimes(5)
@@ -1332,7 +1320,6 @@ describe('CasparCG', () => {
 				useScheduling: true
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
 		expect(commandReceiver0).toHaveBeenCalledTimes(3)
@@ -1349,7 +1336,7 @@ describe('CasparCG', () => {
 		// Check that no commands has been scheduled:
 		expect(await device['queue']).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -1369,7 +1356,7 @@ describe('CasparCG', () => {
 					filter: 'yadif=0:-1'
 				}
 			}
-		]
+		] as TSRTimeline, myLayerMapping)
 
 		await mockTime.advanceTimeToTicks(10200)
 
@@ -1423,7 +1410,7 @@ describe('CasparCG', () => {
 				retryInterval: false // disable retries explicitly, we will manually trigger them
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
 		expect(commandReceiver0).toHaveBeenCalledTimes(0)
@@ -1436,7 +1423,7 @@ describe('CasparCG', () => {
 		// Check that no commands has been scheduled:
 		expect(await device['queue']).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -1452,7 +1439,7 @@ describe('CasparCG', () => {
 					loop: true
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(10200)
 

--- a/src/devices/__tests__/httpsend.spec.ts
+++ b/src/devices/__tests__/httpsend.spec.ts
@@ -42,7 +42,7 @@ describe('HTTP-Send', () => {
 				commandReceiver: commandReceiver0
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
 		let deviceContainer = myConductor.getDevice('myHTTP')
@@ -51,7 +51,7 @@ describe('HTTP-Send', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -70,7 +70,7 @@ describe('HTTP-Send', () => {
 					}
 				}
 			}
-		]
+		])
 		await mockTime.advanceTimeToTicks(10990)
 		expect(commandReceiver0).toHaveBeenCalledTimes(0)
 		await mockTime.advanceTimeToTicks(11100)
@@ -121,7 +121,7 @@ describe('HTTP-Send', () => {
 				commandReceiver: commandReceiver0
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
 		let deviceContainer = myConductor.getDevice('myHTTP')
@@ -180,7 +180,7 @@ describe('HTTP-Send', () => {
 				}
 			}
 		]
-		myConductor.timeline = timeline
+		myConductor.setTimelineAndMappings(timeline)
 
 		await mockTime.advanceTimeToTicks(10990)
 		expect(commandReceiver0).toHaveBeenCalledTimes(0)

--- a/src/devices/__tests__/httpwatcher.spec.ts
+++ b/src/devices/__tests__/httpwatcher.spec.ts
@@ -92,7 +92,7 @@ describe('HTTP-Watcher', () => {
 		expect(generatedDevice).toBeTruthy()
 		expect(await generatedDevice.getStatus()).toEqual({ statusCode: StatusCode.UNKNOWN, active: true })
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		await mockTime.advanceTimeTicks(10100)
 		expect(onGet).toBeCalledTimes(0)
@@ -139,7 +139,7 @@ describe('HTTP-Watcher', () => {
 		expect(generatedDevice).toBeTruthy()
 		expect(await generatedDevice.getStatus()).toEqual({ statusCode: StatusCode.UNKNOWN, active: true })
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		await mockTime.advanceTimeTicks(10100)
 		expect(onGet).toBeCalledTimes(1)
@@ -189,7 +189,7 @@ describe('HTTP-Watcher', () => {
 		expect(generatedDevice).toBeTruthy()
 		expect(await generatedDevice.getStatus()).toEqual({ statusCode: StatusCode.UNKNOWN, active: true })
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		await mockTime.advanceTimeTicks(10100)
 		expect(onGet).toBeCalledTimes(1)
@@ -234,7 +234,7 @@ describe('HTTP-Watcher', () => {
 		})
 		const generatedDevice = generatedDeviceContainer.device
 		expect(await generatedDevice.getStatus()).toEqual({ statusCode: StatusCode.UNKNOWN, active: true })
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 		await mockTime.advanceTimeTicks(10100)
 		expect(onGet).toBeCalledTimes(1)
 		expect(await generatedDevice.getStatus()).toEqual({ statusCode: StatusCode.GOOD, active: true })
@@ -260,7 +260,7 @@ describe('HTTP-Watcher', () => {
 		})
 		const generatedDevice = generatedDeviceContainer.device
 		expect(await generatedDevice.getStatus()).toEqual({ statusCode: StatusCode.UNKNOWN, active: true })
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		await mockTime.advanceTimeTicks(10100)
 		expect(onGetLocal).toBeCalledTimes(1)
@@ -283,7 +283,7 @@ describe('HTTP-Watcher', () => {
 		})
 		const generatedDevice = generatedDeviceContainer.device
 		expect(await generatedDevice.getStatus()).toEqual({ statusCode: StatusCode.UNKNOWN, active: true })
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		await mockTime.advanceTimeTicks(10100)
 		expect(onGet).toBeCalledTimes(1)
@@ -318,7 +318,7 @@ describe('HTTP-Watcher', () => {
 		})
 		const generatedDevice = generatedDeviceContainer.device
 		expect(await generatedDevice.getStatus()).toEqual({ statusCode: StatusCode.UNKNOWN, active: true })
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		await mockTime.advanceTimeTicks(10100)
 		expect(onGetLocal).toBeCalledTimes(1)
@@ -352,7 +352,7 @@ describe('HTTP-Watcher', () => {
 		})
 		const generatedDevice = generatedDeviceContainer.device
 		expect(await generatedDevice.getStatus()).toEqual({ statusCode: StatusCode.UNKNOWN, active: true })
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		await mockTime.advanceTimeTicks(10100)
 		expect(onGet).toBeCalledTimes(0)
@@ -375,7 +375,7 @@ describe('HTTP-Watcher', () => {
 		})
 		const generatedDevice = generatedDeviceContainer.device
 		expect(await generatedDevice.getStatus()).toEqual({ statusCode: StatusCode.UNKNOWN, active: true })
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		await mockTime.advanceTimeTicks(10100)
 		expect(onGet).toBeCalledTimes(1)

--- a/src/devices/__tests__/hyperdeck.spec.ts
+++ b/src/devices/__tests__/hyperdeck.spec.ts
@@ -50,7 +50,7 @@ describe('Hyperdeck', () => {
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 
 		await myConductor.init()
 		await myConductor.addDevice('hyperdeck0', {
@@ -80,7 +80,7 @@ describe('Hyperdeck', () => {
 
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -111,7 +111,7 @@ describe('Hyperdeck', () => {
 					status: TransportStatus.PREVIEW
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(10200)
 
@@ -127,7 +127,7 @@ describe('Hyperdeck', () => {
 			filename: 'sofie_dev'
 		})
 
-		myConductor.timeline = myConductor.timeline // Same timeline
+		myConductor.setTimelineAndMappings(myConductor.timeline) // Same timeline
 		await mockTime.advanceTimeToTicks(10400)
 		expect(hyperdeckMockCommand).toHaveBeenCalledTimes(1) // nothing has changed, so it should not be called again
 

--- a/src/devices/__tests__/lawo.spec.ts
+++ b/src/devices/__tests__/lawo.spec.ts
@@ -47,7 +47,7 @@ describe('Lawo', () => {
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
 		await myConductor.addDevice('myLawo', {
 			type: DeviceType.LAWO,
@@ -66,7 +66,7 @@ describe('Lawo', () => {
 
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -133,8 +133,7 @@ describe('Lawo', () => {
 					triggerValue: 'asdf' // only used for trigging new command sent
 				}
 			}
-		]
-
+		])
 		await mockTime.advanceTimeToTicks(10200)
 
 		expect(commandReceiver0).toHaveBeenCalledTimes(1)
@@ -219,7 +218,7 @@ describe('Lawo', () => {
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
 		await myConductor.addDevice('myLawo', {
 			type: DeviceType.LAWO,
@@ -238,7 +237,7 @@ describe('Lawo', () => {
 
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -317,7 +316,7 @@ describe('Lawo', () => {
 					triggerValue: 'asdf' // only used for trigging new command sent
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(10200)
 
@@ -431,7 +430,7 @@ describe('Lawo', () => {
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
 		await myConductor.addDevice('myLawo', {
 			type: DeviceType.LAWO,
@@ -450,7 +449,7 @@ describe('Lawo', () => {
 
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -524,7 +523,7 @@ describe('Lawo', () => {
 					transitionDuration: 400
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(10200)
 
@@ -603,7 +602,7 @@ describe('Lawo', () => {
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
 		await myConductor.addDevice('myLawo', {
 			type: DeviceType.LAWO,
@@ -622,7 +621,7 @@ describe('Lawo', () => {
 
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -649,7 +648,7 @@ describe('Lawo', () => {
 					value: 80
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(10200)
 
@@ -700,7 +699,7 @@ describe('Lawo', () => {
 			getCurrentTime: mockTime.getCurrentTime
 		})
 		myConductor.on('error', (...args) => console.log(...args))
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
 		await myConductor.addDevice('myLawo', {
 			type: DeviceType.LAWO,
@@ -720,7 +719,7 @@ describe('Lawo', () => {
 
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -738,7 +737,7 @@ describe('Lawo', () => {
 					}
 				}
 			}
-		]
+		])
 
 		expect(await device.queue).toHaveLength(0)
 		await mockTime.advanceTimeToTicks(10500)
@@ -804,7 +803,7 @@ describe('Lawo', () => {
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
 		await myConductor.addDevice('myLawo', {
 			type: DeviceType.LAWO,
@@ -823,7 +822,7 @@ describe('Lawo', () => {
 
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: { start: mockTime.now - 1000 },
@@ -874,7 +873,7 @@ describe('Lawo', () => {
 					'Fader/Motor dB Value': { value: 41 }
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(10200)
 

--- a/src/devices/__tests__/osc.spec.ts
+++ b/src/devices/__tests__/osc.spec.ts
@@ -48,7 +48,7 @@ describe('OSC-Message', () => {
 				port: 80
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
 		let deviceContainer = myConductor.getDevice('osc0')
@@ -57,7 +57,7 @@ describe('OSC-Message', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			literal<TimelineObjOSCMessage>({
 				id: 'obj0',
 				enable: {
@@ -85,7 +85,7 @@ describe('OSC-Message', () => {
 					}]
 				}
 			})
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(10990)
 		expect(commandReceiver0).toHaveBeenCalledTimes(0)
@@ -141,7 +141,7 @@ describe('OSC-Message', () => {
 				port: 80
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
 		let deviceContainer = myConductor.getDevice('osc0')
@@ -150,7 +150,7 @@ describe('OSC-Message', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			literal<TimelineObjOSCMessage>({
 				id: 'obj0',
 				enable: {
@@ -193,7 +193,7 @@ describe('OSC-Message', () => {
 					}
 				}
 			})
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(10990)
 		expect(commandReceiver0).toHaveBeenCalledTimes(0)

--- a/src/devices/__tests__/panasonicPTZ.spec.ts
+++ b/src/devices/__tests__/panasonicPTZ.spec.ts
@@ -77,7 +77,7 @@ describe('Panasonic PTZ', () => {
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
 		await myConductor.addDevice('myPtz', {
 			type: DeviceType.PANASONIC_PTZ,
@@ -94,7 +94,7 @@ describe('Panasonic PTZ', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -199,7 +199,7 @@ describe('Panasonic PTZ', () => {
 					zoomSpeed: 1
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(10200)
 

--- a/src/devices/__tests__/pharos.spec.ts
+++ b/src/devices/__tests__/pharos.spec.ts
@@ -76,7 +76,7 @@ describe('Pharos', () => {
 				host: '127.0.0.1'
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		let wsInstances = WebSocket.getMockInstances()
 		expect(wsInstances).toHaveLength(1)
@@ -93,7 +93,7 @@ describe('Pharos', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'scene0',
 				enable: {
@@ -137,7 +137,7 @@ describe('Pharos', () => {
 					stopped: true
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(10990)
 		expect(commandReceiver0).toHaveBeenCalledTimes(0)

--- a/src/devices/__tests__/quantel.spec.ts
+++ b/src/devices/__tests__/quantel.spec.ts
@@ -93,7 +93,7 @@ describe('Quantel', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -133,7 +133,7 @@ describe('Quantel', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'video0',
 				enable: {
@@ -154,7 +154,7 @@ describe('Quantel', () => {
 					// noStarttime?: boolean
 				}
 			}
-		]
+		])
 		// Time to preload the clip
 		await mockTime.advanceTimeToTicks(10990)
 
@@ -266,7 +266,7 @@ describe('Quantel', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
 
@@ -305,7 +305,7 @@ describe('Quantel', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'video0',
 				enable: {
@@ -326,7 +326,7 @@ describe('Quantel', () => {
 					// noStarttime?: boolean
 				}
 			}
-		]
+		])
 		// Time to preload the clip
 		await mockTime.advanceTimeToTicks(10990)
 
@@ -438,7 +438,7 @@ describe('Quantel', () => {
 		device.on('error', console.log)
 		device.on('commandError', console.log)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		await mockTime.advanceTimeToTicks(15000)
 		clearMocks()
@@ -448,7 +448,7 @@ describe('Quantel', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'video0',
 				enable: {
@@ -497,7 +497,7 @@ describe('Quantel', () => {
 					inPoint: 500
 				}
 			}
-		]
+		])
 		// What's going to happen:
 		// 15000: clip Test0 starts playing
 		// 15200: clip myClip starts playing (replaces old clip)
@@ -679,7 +679,7 @@ describe('Quantel', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -719,7 +719,7 @@ describe('Quantel', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'video0',
 				enable: {
@@ -737,7 +737,7 @@ describe('Quantel', () => {
 					}
 				}
 			}
-		]
+		])
 		// Time to preload the clip
 		await mockTime.advanceTimeToTicks(10990)
 
@@ -858,7 +858,7 @@ describe('Quantel', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -898,7 +898,7 @@ describe('Quantel', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'video0',
 				enable: {
@@ -932,7 +932,7 @@ describe('Quantel', () => {
 					playing: false
 				}
 			}
-		]
+		])
 		// Time to preload the clip
 		await mockTime.advanceTimeToTicks(10990)
 

--- a/src/devices/__tests__/singularLive.spec.ts
+++ b/src/devices/__tests__/singularLive.spec.ts
@@ -47,7 +47,7 @@ describe('Singular.Live', () => {
 				accessToken: 'DUMMY_TOKEN'
 			}
 		})
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
 		let deviceContainer = myConductor.getDevice('mySingular')
@@ -56,7 +56,7 @@ describe('Singular.Live', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -75,7 +75,7 @@ describe('Singular.Live', () => {
 					}
 				}
 			}
-		]
+		])
 		await mockTime.advanceTimeToTicks(10990)
 		expect(commandReceiver0).toHaveBeenCalledTimes(0)
 		await mockTime.advanceTimeToTicks(11100)

--- a/src/devices/__tests__/sisyfos.spec.ts
+++ b/src/devices/__tests__/sisyfos.spec.ts
@@ -2,7 +2,8 @@ jest.mock('osc')
 import { Conductor } from '../../conductor'
 import {
 	Mappings,
-	DeviceType
+	DeviceType,
+	TSRTimeline
 } from '../../types/src'
 import { MockOSC } from '../../__mocks__/osc'
 import { MockTime } from '../../__tests__/mockTime'
@@ -69,7 +70,7 @@ describe('Sisyfos', () => {
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
 		await myConductor.addDevice('mySisyfos', {
 			type: DeviceType.SISYFOS,
@@ -87,7 +88,7 @@ describe('Sisyfos', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -188,7 +189,7 @@ describe('Sisyfos', () => {
 					visible: true
 				}
 			}
-		]
+		] as TSRTimeline)
 
 		await mockTime.advanceTimeTicks(100) // now-ish
 		expect(commandReceiver0.mock.calls.length).toEqual(1)
@@ -284,7 +285,7 @@ describe('Sisyfos', () => {
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
 		await myConductor.addDevice('mySisyfos', {
 			type: DeviceType.SISYFOS,
@@ -302,7 +303,7 @@ describe('Sisyfos', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -401,7 +402,7 @@ describe('Sisyfos', () => {
 					visible: true
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeTicks(100) // now-ish
 		expect(commandReceiver0.mock.calls.length).toEqual(1)
@@ -498,7 +499,7 @@ describe('Sisyfos', () => {
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
 		await myConductor.addDevice('mySisyfos', {
 			type: DeviceType.SISYFOS,
@@ -516,7 +517,7 @@ describe('Sisyfos', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -563,7 +564,7 @@ describe('Sisyfos', () => {
 				isLookahead: true,
 				lookaheadForLayer: 'sisyfos_channel_2'
 			}
-		]
+		])
 
 		await mockTime.advanceTimeTicks(100) // now-ish
 		expect(commandReceiver0.mock.calls.length).toEqual(1)
@@ -626,7 +627,7 @@ describe('Sisyfos', () => {
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
 		await myConductor.addDevice('mySisyfos', {
 			type: DeviceType.SISYFOS,
@@ -644,7 +645,7 @@ describe('Sisyfos', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'baseline',
 				enable: {
@@ -720,7 +721,7 @@ describe('Sisyfos', () => {
 					overridePriority: -999
 				}
 			}
-		]
+		])
 
 		// baseline:
 		await mockTime.advanceTimeTicks(100) // 100
@@ -798,7 +799,7 @@ describe('Sisyfos', () => {
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
-		// await myConductor.setMapping(myChannelMapping)
+		// myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init()
 		await myConductor.addDevice('mySisyfos', {
 			type: DeviceType.SISYFOS,

--- a/src/devices/__tests__/tcpSend.spec.ts
+++ b/src/devices/__tests__/tcpSend.spec.ts
@@ -91,7 +91,7 @@ describe('TCP-Send', () => {
 		expect(sockets).toHaveLength(1)
 		let socket = sockets[0]
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100) // 10100
 		expect(mockTime.now).toEqual(10100)
 		expect(onConnection).toHaveBeenCalledTimes(1)
@@ -108,7 +108,7 @@ describe('TCP-Send', () => {
 		expect(await device.queue).toHaveLength(0)
 
 		// Test Added object:
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -121,7 +121,7 @@ describe('TCP-Send', () => {
 					message: 'hello world'
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(10990)
 
@@ -138,7 +138,7 @@ describe('TCP-Send', () => {
 		expect(onSocketWrite.mock.calls[0][0]).toEqual(Buffer.from('hello world'))
 
 		// Test Changed object:
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -151,7 +151,7 @@ describe('TCP-Send', () => {
 					message: 'anyone here'
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(12000) // 12000
 		expect(commandReceiver0).toHaveBeenCalledTimes(2)

--- a/src/devices/__tests__/vizMSE.spec.ts
+++ b/src/devices/__tests__/vizMSE.spec.ts
@@ -2,7 +2,8 @@ jest.mock('v-connection')
 import { Conductor } from '../../conductor'
 import {
 	Mappings,
-	DeviceType
+	DeviceType,
+	TSRTimeline
 } from '../../types/src'
 import { MockTime } from '../../__tests__/mockTime'
 import { ThreadedClass } from 'threadedclass'
@@ -46,7 +47,7 @@ describe('vizMSE', () => {
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init()
 		await myConductor.addDevice('myViz', {
 			type: DeviceType.VIZMSE,
@@ -68,7 +69,7 @@ describe('vizMSE', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -116,7 +117,7 @@ describe('vizMSE', () => {
 					reference: 'viz0'
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeTicks(500) // 10500
 		expect(commandReceiver0.mock.calls.length).toEqual(0)
@@ -224,7 +225,7 @@ describe('vizMSE', () => {
 		const onError = jest.fn()
 		myConductor.on('error', onError)
 
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init()
 		await myConductor.addDevice('myViz', {
 			type: DeviceType.VIZMSE,
@@ -245,7 +246,7 @@ describe('vizMSE', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -292,7 +293,7 @@ describe('vizMSE', () => {
 					reference: 'viz0'
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeTicks(500) // 10500
 		expect(commandReceiver0.mock.calls.length).toEqual(0)
@@ -437,7 +438,7 @@ describe('vizMSE', () => {
 			}
 		])
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'loadAll',
 				enable: {
@@ -450,7 +451,7 @@ describe('vizMSE', () => {
 					type: TimelineContentTypeVizMSE.LOAD_ALL_ELEMENTS
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(24900)
 
@@ -599,7 +600,7 @@ describe('vizMSE', () => {
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init()
 		await myConductor.addDevice('myViz', {
 			type: DeviceType.VIZMSE,
@@ -623,7 +624,7 @@ describe('vizMSE', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -652,7 +653,7 @@ describe('vizMSE', () => {
 					commands: ['RENDERER*FRONT_LAYER SET_OBJECT ', 'RENDERER SET_OBJECT ']
 				}
 			}
-		]
+		] as TSRTimeline)
 
 		// await mockTime.advanceTimeTicks(500) // 10500
 		// expect(commandReceiver0.mock.calls.length).toEqual(0)
@@ -767,7 +768,7 @@ describe('vizMSE', () => {
 		const onError = jest.fn()
 		myConductor.on('error', onError)
 
-		await myConductor.setMapping(myChannelMapping)
+		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init()
 		await myConductor.addDevice('myViz', {
 			type: DeviceType.VIZMSE,
@@ -795,7 +796,7 @@ describe('vizMSE', () => {
 		const rundown = _.last(mse.getMockRundowns()) as VRundownMocked
 		expect(rundown).toBeTruthy()
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'obj0',
 				enable: {
@@ -815,7 +816,7 @@ describe('vizMSE', () => {
 
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(14000)
 		expect(commandReceiver0.mock.calls.length).toEqual(0)

--- a/src/devices/__tests__/vmix.spec.ts
+++ b/src/devices/__tests__/vmix.spec.ts
@@ -99,7 +99,7 @@ describe('vMix', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -113,7 +113,7 @@ describe('vMix', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'media',
 				enable: {
@@ -129,7 +129,7 @@ describe('vMix', () => {
 					playing: true
 				}
 			}
-		]
+		])
 		// Time to preload the clip
 		await mockTime.advanceTimeToTicks(10990)
 
@@ -233,7 +233,7 @@ describe('vMix', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -244,7 +244,7 @@ describe('vMix', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'media',
 				enable: {
@@ -272,7 +272,7 @@ describe('vMix', () => {
 					}
 				}
 			}
-		]
+		])
 		// Time to preload the clip
 		await mockTime.advanceTimeToTicks(10990)
 
@@ -427,7 +427,7 @@ describe('vMix', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -438,7 +438,7 @@ describe('vMix', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'media',
 				enable: {
@@ -457,7 +457,7 @@ describe('vMix', () => {
 					}
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(11300)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(1, 11000, expect.objectContaining({
@@ -596,7 +596,7 @@ describe('vMix', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -607,7 +607,7 @@ describe('vMix', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'media0',
 				enable: {
@@ -662,7 +662,7 @@ describe('vMix', () => {
 					filePath: 'G:/videos/My Other Clip.mp4'
 				}
 			}
-		]
+		])
 		// Time to preload the clip
 		await mockTime.advanceTimeToTicks(10990)
 
@@ -816,7 +816,7 @@ describe('vMix', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -827,7 +827,7 @@ describe('vMix', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'audio',
 				enable: {
@@ -846,7 +846,7 @@ describe('vMix', () => {
 					audioBuses: 'A,C,F'
 				}
 			}
-		]
+		])
 		await mockTime.advanceTimeToTicks(11300)
 
 		expect(commandReceiver0).toHaveBeenCalledTimes(8)
@@ -1060,7 +1060,7 @@ describe('vMix', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -1074,7 +1074,7 @@ describe('vMix', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'program0',
 				enable: {
@@ -1157,7 +1157,7 @@ describe('vMix', () => {
 					input: 4
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(11300)
 
@@ -1253,7 +1253,7 @@ describe('vMix', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -1267,7 +1267,7 @@ describe('vMix', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'lowerthird0',
 				enable: {
@@ -1281,7 +1281,7 @@ describe('vMix', () => {
 					input: 1
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(11300)
 
@@ -1365,7 +1365,7 @@ describe('vMix', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -1379,7 +1379,7 @@ describe('vMix', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'recording0',
 				enable: {
@@ -1393,7 +1393,7 @@ describe('vMix', () => {
 					on: true
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(11300)
 
@@ -1474,7 +1474,7 @@ describe('vMix', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -1488,7 +1488,7 @@ describe('vMix', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'external0',
 				enable: {
@@ -1502,7 +1502,7 @@ describe('vMix', () => {
 					on: true
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(11300)
 
@@ -1583,7 +1583,7 @@ describe('vMix', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -1597,7 +1597,7 @@ describe('vMix', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'external0',
 				enable: {
@@ -1611,7 +1611,7 @@ describe('vMix', () => {
 					on: true
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(11300)
 
@@ -1693,7 +1693,7 @@ describe('vMix', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -1707,7 +1707,7 @@ describe('vMix', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'external0',
 				enable: {
@@ -1721,7 +1721,7 @@ describe('vMix', () => {
 					source: 'Preview'
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(11300)
 
@@ -1807,7 +1807,7 @@ describe('vMix', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -1821,7 +1821,7 @@ describe('vMix', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'output0',
 				enable: {
@@ -1836,7 +1836,7 @@ describe('vMix', () => {
 					input: 2
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(11300)
 
@@ -1922,7 +1922,7 @@ describe('vMix', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -1936,7 +1936,7 @@ describe('vMix', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'ftb0',
 				enable: {
@@ -1950,7 +1950,7 @@ describe('vMix', () => {
 					on: true
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(11300)
 
@@ -2031,7 +2031,7 @@ describe('vMix', () => {
 		device.on('error', deviceErrorHandler)
 		device.on('commandError', deviceErrorHandler)
 
-		await myConductor.setMapping(myLayerMapping)
+		myConductor.setTimelineAndMappings([], myLayerMapping)
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
 		await mockTime.advanceTimeToTicks(10100)
@@ -2045,7 +2045,7 @@ describe('vMix', () => {
 		// Check that no commands has been scheduled:
 		expect(await device.queue).toHaveLength(0)
 
-		myConductor.timeline = [
+		myConductor.setTimelineAndMappings([
 			{
 				id: 'fader0',
 				enable: {
@@ -2059,7 +2059,7 @@ describe('vMix', () => {
 					position: 126
 				}
 			}
-		]
+		])
 
 		await mockTime.advanceTimeToTicks(11300)
 

--- a/src/devices/abstract.ts
+++ b/src/devices/abstract.ts
@@ -6,7 +6,7 @@ import {
 	StatusCode,
 	IDevice
 } from './device'
-import { DeviceType, AbstractOptions, DeviceOptionsAbstract } from '../types/src'
+import { DeviceType, AbstractOptions, DeviceOptionsAbstract, Mappings } from '../types/src'
 
 import { TimelineState, ResolvedTimelineObjectInstance } from 'superfly-timeline'
 import { DoOnTime, SendMode } from '../doOnTime'
@@ -27,13 +27,14 @@ export interface DeviceOptionsAbstractInternal extends DeviceOptionsAbstract {
 	)
 }
 export type CommandReceiver = (time: number, cmd: Command, context: CommandContext, timelineObjId: string) => Promise<any>
+type AbstractState = TimelineState
 /*
 	This is a wrapper for an "Abstract" device
 
 	An abstract device is just a test-device that doesn't really do anything, but can be used
 	as a preliminary mock
 */
-export class AbstractDevice extends DeviceWithState<TimelineState> implements IDevice {
+export class AbstractDevice extends DeviceWithState<AbstractState> implements IDevice {
 	private _doOnTime: DoOnTime
 
 	private _commandReceiver: CommandReceiver
@@ -69,7 +70,8 @@ export class AbstractDevice extends DeviceWithState<TimelineState> implements ID
 	 * Handle a new state, at the point in time specified
 	 * @param newState
 	 */
-	handleState (newState: TimelineState) {
+	handleState (newState: TimelineState, newMappings: Mappings) {
+		super.onHandleState(newState, newMappings)
 		let previousStateTime = Math.max(this.getCurrentTime(), newState.time)
 		let oldState: TimelineState = (this.getStateBefore(previousStateTime) || { state: { time: 0, layers: {}, nextEvents: [] } }).state
 

--- a/src/devices/atem.ts
+++ b/src/devices/atem.ts
@@ -21,7 +21,8 @@ import {
 	TimelineObjAtemAUX,
 	TimelineObjAtemSsrcProps,
 	TimelineObjAtemMacroPlayer,
-	DeviceOptionsAtem
+	DeviceOptionsAtem,
+	Mappings
 } from '../types/src'
 import { TimelineState } from 'superfly-timeline'
 import {
@@ -164,7 +165,8 @@ export class AtemDevice extends DeviceWithState<DeviceState> implements IDevice 
 	 * be executed at the state's time.
 	 * @param newState The state to handle
 	 */
-	handleState (newState: TimelineState) {
+	handleState (newState: TimelineState, newMappings: Mappings) {
+		super.onHandleState(newState, newMappings)
 		if (!this._initialized) { // before it's initialized don't do anything
 			this.emit('warning', 'Atem not initialized yet')
 			return
@@ -174,7 +176,7 @@ export class AtemDevice extends DeviceWithState<DeviceState> implements IDevice 
 		let oldState: DeviceState = (this.getStateBefore(previousStateTime) || { state: AtemConnection.AtemStateUtil.Create() }).state
 
 		let oldAtemState = oldState
-		let newAtemState = this.convertStateToAtem(newState)
+		let newAtemState = this.convertStateToAtem(newState, newMappings)
 
 		if (this.firstStateAfterMakeReady) { // emit a debug message with the states:
 			this.firstStateAfterMakeReady = false
@@ -208,7 +210,7 @@ export class AtemDevice extends DeviceWithState<DeviceState> implements IDevice 
 	 * Convert a timeline state into an Atem state.
 	 * @param state The state to be converted
 	 */
-	convertStateToAtem (state: TimelineState): DeviceState {
+	convertStateToAtem (state: TimelineState, newMappings: Mappings): DeviceState {
 		if (!this._initialized) throw Error('convertStateToAtem cannot be used before inititialized')
 
 		// Start out with default state:
@@ -222,7 +224,7 @@ export class AtemDevice extends DeviceWithState<DeviceState> implements IDevice 
 		_.each(sortedLayers, ({ tlObject, layerName }) => {
 			// const content = tlObject.content
 
-			let mapping = this.getMapping()[layerName] as MappingAtem | undefined
+			let mapping = newMappings[layerName] as MappingAtem | undefined
 
 			if (mapping && mapping.deviceId === this.deviceId) {
 				if (mapping.index !== undefined && mapping.index >= 0) { // index must be 0 or higher

--- a/src/devices/casparCG.ts
+++ b/src/devices/casparCG.ts
@@ -28,7 +28,8 @@ import {
 	TimelineObjCCGProducerContentBase,
 	ResolvedTimelineObjectInstanceExtended,
 	TimelineObjCCGIP,
-	DeviceOptionsCasparCG
+	DeviceOptionsCasparCG,
+	Mappings
 } from '../types/src'
 
 import {
@@ -59,7 +60,7 @@ export type CommandReceiver = (time: number, cmd: CommandNS.IAMCPCommand, contex
  * commands. It depends on the DoOnTime class to execute the commands timely or,
  * optionally, uses the CasparCG command scheduling features.
  */
-export class CasparCGDevice extends DeviceWithState<TimelineState> implements IDevice {
+export class CasparCGDevice extends DeviceWithState<StateNS.State> implements IDevice {
 
 	private _ccg: CasparCG
 	private _ccgState: CasparCGState
@@ -169,7 +170,8 @@ export class CasparCGDevice extends DeviceWithState<TimelineState> implements ID
 	/**
 	 * Generates an array of CasparCG commands by comparing the newState against the oldState, or the current device state.
 	 */
-	handleState (newState: TimelineState) {
+	handleState (newState: TimelineState, newMappings: Mappings) {
+		super.onHandleState(newState, newMappings)
 		// check if initialized:
 		if (!this._ccgState.isInitialised) {
 			this.emit('warning', 'CasparCG State not initialized yet')
@@ -178,10 +180,9 @@ export class CasparCGDevice extends DeviceWithState<TimelineState> implements ID
 
 		let previousStateTime = Math.max(this.getCurrentTime(), newState.time)
 
-		let oldState: TimelineState = (this.getStateBefore(previousStateTime) || ({ state: { time: 0, layers: {}, nextEvents: [] } })).state
+		let oldCasparState = (this.getStateBefore(previousStateTime) || { state: new StateNS.State() }).state
 
-		let newCasparState = this.convertStateToCaspar(newState)
-		let oldCasparState = this.convertStateToCaspar(oldState)
+		let newCasparState = this.convertStateToCaspar(newState, newMappings)
 
 		let commandsToAchieveState = this._diffStates(oldCasparState, newCasparState, newState.time)
 
@@ -195,7 +196,7 @@ export class CasparCGDevice extends DeviceWithState<TimelineState> implements ID
 		this._addToQueue(commandsToAchieveState, newState.time)
 
 		// store the new state, for later use:
-		this.setState(newState, newState.time)
+		this.setState(newCasparState, newState.time)
 	}
 
 	/**
@@ -244,7 +245,7 @@ export class CasparCGDevice extends DeviceWithState<TimelineState> implements ID
 		}
 	}
 
-	private convertObjectToCasparState (layer: ResolvedTimelineObjectInstance, mapping: MappingCasparCG, isForeground: boolean): StateNS.ILayerBase {
+	private convertObjectToCasparState (mappings: Mappings, layer: ResolvedTimelineObjectInstance, mapping: MappingCasparCG, isForeground: boolean): StateNS.ILayerBase {
 		let startTime = layer.instance.originalStart || layer.instance.start
 		if (startTime === 0) startTime = 1 // @todo: startTime === 0 will make ccg-state seek to the current time
 
@@ -342,7 +343,7 @@ export class CasparCGDevice extends DeviceWithState<TimelineState> implements ID
 			const routeObj = layer as any as TimelineObjCCGRoute
 
 			if (routeObj.content.mappedLayer) {
-				let routeMapping = this.getMapping()[routeObj.content.mappedLayer] as MappingCasparCG
+				let routeMapping = mappings[routeObj.content.mappedLayer] as MappingCasparCG
 				if (routeMapping && routeMapping.deviceId === this.deviceId) {
 					routeObj.content.channel	= routeMapping.channel
 					routeObj.content.layer		= routeMapping.layer
@@ -435,11 +436,11 @@ export class CasparCGDevice extends DeviceWithState<TimelineState> implements ID
 	 * Takes a timeline state and returns a CasparCG State that will work with the state lib.
 	 * @param timelineState The timeline state to generate from.
 	 */
-	convertStateToCaspar (timelineState: TimelineState): StateNS.State {
+	convertStateToCaspar (timelineState: TimelineState, mappings: Mappings): StateNS.State {
 
 		const caspar = new StateNS.State()
 
-		_.each(this.getMapping(), (foundMapping, layerName) => {
+		_.each(mappings, (foundMapping, layerName) => {
 			if (
 				foundMapping &&
 				foundMapping.device === DeviceType.CASPARCG &&
@@ -476,8 +477,8 @@ export class CasparCGDevice extends DeviceWithState<TimelineState> implements ID
 				}
 
 				// create layer of appropriate type
-				const foregroundStateLayer = foregroundObj ? this.convertObjectToCasparState(foregroundObj, mapping, true) : undefined
-				const backgroundStateLayer = backgroundObj ? this.convertObjectToCasparState(backgroundObj, mapping, false) : undefined
+				const foregroundStateLayer = foregroundObj ? this.convertObjectToCasparState(mappings, foregroundObj, mapping, true) : undefined
+				const backgroundStateLayer = backgroundObj ? this.convertObjectToCasparState(mappings, backgroundObj, mapping, false) : undefined
 
 				if (foregroundStateLayer) {
 					channel.layers[mapping.layer] = {
@@ -768,7 +769,7 @@ export class CasparCGDevice extends DeviceWithState<TimelineState> implements ID
 			) {
 				const currentState = this.getState(time)
 				if (currentState) {
-					const currentCasparState = this.convertStateToCaspar(currentState.state)
+					const currentCasparState = currentState.state
 
 					const trackedState = this._ccgState.getState()
 
@@ -833,7 +834,7 @@ export class CasparCGDevice extends DeviceWithState<TimelineState> implements ID
 
 		if (!tlState) return // no state implies any state is correct
 
-		const ccgState = this.convertStateToCaspar(tlState.state)
+		const ccgState = tlState.state
 
 		const diff = this._ccgState.getDiff(ccgState, this.getCurrentTime())
 

--- a/src/devices/httpSend.ts
+++ b/src/devices/httpSend.ts
@@ -10,7 +10,8 @@ import {
 	DeviceType,
 	HTTPSendOptions,
 	HTTPSendCommandContent,
-	DeviceOptionsHTTPSend
+	DeviceOptionsHTTPSend,
+	Mappings
 } from '../types/src'
 import { DoOnTime, SendMode } from '../doOnTime'
 import * as request from 'request'
@@ -34,10 +35,12 @@ interface Command {
 }
 type CommandContext = string
 
+type HTTPSendState = TimelineState
+
 /**
  * This is a HTTPSendDevice, it sends http commands when it feels like it
  */
-export class HTTPSendDevice extends DeviceWithState<TimelineState> implements IDevice {
+export class HTTPSendDevice extends DeviceWithState<HTTPSendState> implements IDevice {
 
 	private _makeReadyCommands: HTTPSendCommandContent[]
 	private _makeReadyDoesReset: boolean
@@ -68,16 +71,17 @@ export class HTTPSendDevice extends DeviceWithState<TimelineState> implements ID
 		this._doOnTime.clearQueueNowAndAfter(newStateTime)
 		this.cleanUpStates(0, newStateTime)
 	}
-	handleState (newState: TimelineState) {
+	handleState (newState: TimelineState, newMappings: Mappings) {
+		super.onHandleState(newState, newMappings)
 		// Handle this new state, at the point in time specified
 
 		let previousStateTime = Math.max(this.getCurrentTime(), newState.time)
 		let oldState: TimelineState = (this.getStateBefore(previousStateTime) || { state: { time: 0, layers: {}, nextEvents: [] } }).state
 
-		let oldAbstractState = this.convertStateToHttpSend(oldState)
-		let newAbstractState = this.convertStateToHttpSend(newState)
+		let oldHttpSendState = oldState
+		let newHttpSendState = this.convertStateToHttpSend(newState)
 
-		let commandsToAchieveState: Array<any> = this._diffStates(oldAbstractState, newAbstractState)
+		let commandsToAchieveState: Array<any> = this._diffStates(oldHttpSendState, newHttpSendState)
 
 		// clear any queued commands later than this time:
 		this._doOnTime.clearQueueNowAndAfter(previousStateTime)

--- a/src/devices/httpWatcher.ts
+++ b/src/devices/httpWatcher.ts
@@ -9,7 +9,8 @@ import {
 	DeviceType,
 	TimelineContentTypeHTTP,
 	HTTPWatcherOptions,
-	DeviceOptionsHTTPpWatcher
+	DeviceOptionsHTTPpWatcher,
+	Mappings
 } from '../types/src'
 import * as request from 'request'
 
@@ -117,7 +118,8 @@ export class HTTPWatcherDevice extends Device implements IDevice {
 	prepareForHandleState (_newStateTime: number) {
 		// NOP
 	}
-	handleState (_newState: TimelineState) {
+	handleState (newState: TimelineState, newMappings: Mappings) {
+		super.onHandleState(newState, newMappings)
 		// NOP
 	}
 	clearFuture (_clearAfterTime: number) {

--- a/src/devices/hyperdeck.ts
+++ b/src/devices/hyperdeck.ts
@@ -16,7 +16,8 @@ import {
 	HyperdeckOptions,
 	TimelineObjHyperdeckTransport,
 	TimelineObjHyperdeckAny,
-	DeviceOptionsHyperdeck
+	DeviceOptionsHyperdeck,
+	Mappings
 } from '../types/src'
 import {
 	Hyperdeck,
@@ -226,7 +227,8 @@ export class HyperdeckDevice extends DeviceWithState<DeviceState> implements IDe
 	 * that state at that time.
 	 * @param newState
 	 */
-	handleState (newState: TimelineState) {
+	handleState (newState: TimelineState, newMappings: Mappings) {
+		super.onHandleState(newState, newMappings)
 		if (!this._initialized) {
 			// before it's initialized don't do anything
 			this.emit('info', 'Hyperdeck not initialized yet')
@@ -238,7 +240,7 @@ export class HyperdeckDevice extends DeviceWithState<DeviceState> implements IDe
 		let oldState: DeviceState = (this.getStateBefore(previousStateTime) || { state: this._getDefaultState() }).state
 
 		let oldHyperdeckState = oldState
-		let newHyperdeckState = this.convertStateToHyperdeck(newState)
+		let newHyperdeckState = this.convertStateToHyperdeck(newState, newMappings)
 
 		// Generate commands to transition to new state
 		let commandsToAchieveState: Array<HyperdeckCommandWithContext> = this._diffStates(oldHyperdeckState, newHyperdeckState)
@@ -268,7 +270,7 @@ export class HyperdeckDevice extends DeviceWithState<DeviceState> implements IDe
 	 * Converts a timeline state to a device state.
 	 * @param state
 	 */
-	convertStateToHyperdeck (state: TimelineState): DeviceState {
+	convertStateToHyperdeck (state: TimelineState, mappings: Mappings): DeviceState {
 		if (!this._initialized) throw Error('convertStateToHyperdeck cannot be used before inititialized')
 
 		// Convert the timeline state into something we can use easier:
@@ -280,7 +282,7 @@ export class HyperdeckDevice extends DeviceWithState<DeviceState> implements IDe
 
 			const hyperdeckObj = tlObject as any as TimelineObjHyperdeckAny
 
-			const mapping = this.getMapping()[layerName] as MappingHyperdeck
+			const mapping = mappings[layerName] as MappingHyperdeck
 
 			if (mapping && mapping.deviceId === this.deviceId) {
 				switch (mapping.mappingType) {

--- a/src/devices/osc.ts
+++ b/src/devices/osc.ts
@@ -12,7 +12,8 @@ import {
 	OSCOptions,
 	SomeOSCValue,
 	OSCValueType,
-	DeviceOptionsOSC
+	DeviceOptionsOSC,
+	Mappings
 } from '../types/src'
 import { DoOnTime, SendMode } from '../doOnTime'
 
@@ -48,7 +49,7 @@ interface OSCDeviceStateContent extends OSCMessageCommandContent {
 /**
  * This is a generic wrapper for any osc-enabled device.
  */
-export class OSCMessageDevice extends DeviceWithState<TimelineState> implements IDevice {
+export class OSCMessageDevice extends DeviceWithState<OSCDeviceState> implements IDevice {
 
 	private _doOnTime: DoOnTime
 	private _oscClient: osc.UDPPort
@@ -98,16 +99,16 @@ export class OSCMessageDevice extends DeviceWithState<TimelineState> implements 
 	 * in time.
 	 * @param newState
 	 */
-	handleState (newState: TimelineState) {
+	handleState (newState: TimelineState, newMappings: Mappings) {
+		super.onHandleState(newState, newMappings)
 		// Transform timeline states into device states
 		let previousStateTime = Math.max(this.getCurrentTime(), newState.time)
-		let oldState: TimelineState = (this.getStateBefore(previousStateTime) || { state: { time: 0, layers: {}, nextEvents: [] } }).state
+		let oldOSCState: OSCDeviceState = (this.getStateBefore(previousStateTime) || { state: { } }).state
 
-		let oldAbstractState = this.convertStateToOSCMessage(oldState)
-		let newAbstractState = this.convertStateToOSCMessage(newState)
+		let newOSCState = this.convertStateToOSCMessage(newState)
 
 		// Generate commands necessary to transition to the new state
-		let commandsToAchieveState: Array<any> = this._diffStates(oldAbstractState, newAbstractState)
+		let commandsToAchieveState: Array<any> = this._diffStates(oldOSCState, newOSCState)
 
 		// clear any queued commands later than this time:
 		this._doOnTime.clearQueueNowAndAfter(previousStateTime)
@@ -115,7 +116,7 @@ export class OSCMessageDevice extends DeviceWithState<TimelineState> implements 
 		this._addToQueue(commandsToAchieveState, newState.time)
 
 		// store the new state, for later use:
-		this.setState(newState, newState.time)
+		this.setState(newOSCState, newState.time)
 	}
 	/**
 	 * Clear any scheduled commands after this time

--- a/src/devices/panasonicPTZ.ts
+++ b/src/devices/panasonicPTZ.ts
@@ -16,7 +16,8 @@ import {
 	MappingPanasonicPtz,
 	MappingPanasonicPtzType,
 	PanasonicPTZOptions,
-	DeviceOptionsPanasonicPTZ
+	DeviceOptionsPanasonicPTZ,
+	Mappings
 } from '../types/src'
 import { TimelineState, ResolvedTimelineObjectInstance } from 'superfly-timeline'
 import { DoOnTime, SendMode } from '../doOnTime'
@@ -69,7 +70,7 @@ const PROBE_INTERVAL = 10 * 1000 // Probe every 10s
  * executes commands to achieve such states. Depends on PanasonicPTZAPI class for
  * connection with the physical device.
  */
-export class PanasonicPtzDevice extends DeviceWithState<TimelineState> implements IDevice {
+export class PanasonicPtzDevice extends DeviceWithState<PanasonicPtzState> implements IDevice {
 	private _doOnTime: DoOnTime
 	private _device: PanasonicPtzHttpInterface | undefined
 	private _connected: boolean = false
@@ -139,12 +140,12 @@ export class PanasonicPtzDevice extends DeviceWithState<TimelineState> implement
 	 * Converts a timeline state into a device state.
 	 * @param state
 	 */
-	convertStateToPtz (state: TimelineState): PanasonicPtzState {
+	convertStateToPtz (state: TimelineState, mappings: Mappings): PanasonicPtzState {
 		// convert the timeline state into something we can use
 		const ptzState: PanasonicPtzState = this._getDefaultState()
 
 		_.each(state.layers, (tlObject: ResolvedTimelineObjectInstance, layerName: string) => {
-			const mapping: MappingPanasonicPtz | undefined = this.getMapping()[layerName] as MappingPanasonicPtz
+			const mapping: MappingPanasonicPtz | undefined = mappings[layerName] as MappingPanasonicPtz
 			if (mapping && mapping.device === DeviceType.PANASONIC_PTZ && mapping.deviceId === this.deviceId) {
 
 				if (mapping.mappingType === MappingPanasonicPtzType.PRESET) {
@@ -188,13 +189,13 @@ export class PanasonicPtzDevice extends DeviceWithState<TimelineState> implement
 	 * in time.
 	 * @param newState
 	 */
-	handleState (newState: TimelineState) {
+	handleState (newState: TimelineState, newMappings: Mappings) {
+		super.onHandleState(newState, newMappings)
 		// Create device states
 		let previousStateTime = Math.max(this.getCurrentTime(), newState.time)
-		let oldState: TimelineState = (this.getStateBefore(previousStateTime) || { state: { time: 0, layers: {}, nextEvents: [] } }).state
+		let oldPtzState: PanasonicPtzState = (this.getStateBefore(previousStateTime) || { state: this._getDefaultState() }).state
 
-		let oldPtzState = this.convertStateToPtz(oldState)
-		let newPtzState = this.convertStateToPtz(newState)
+		let newPtzState = this.convertStateToPtz(newState, newMappings)
 
 		// Generate commands needed to reach new state
 		let commandsToAchieveState: Array<PanasonicPtzCommandWithContext> = this._diffStates(oldPtzState, newPtzState)
@@ -205,7 +206,7 @@ export class PanasonicPtzDevice extends DeviceWithState<TimelineState> implement
 		this._addToQueue(commandsToAchieveState, newState.time)
 
 		// store the new state, for later use:
-		this.setState(newState, newState.time)
+		this.setState(newPtzState, newState.time)
 	}
 
 	clearFuture (clearAfterTime: number) {

--- a/src/devices/pharos.ts
+++ b/src/devices/pharos.ts
@@ -13,7 +13,8 @@ import {
 	TimelineObjPharos,
 	TimelineObjPharosScene,
 	TimelineObjPharosTimeline,
-	DeviceOptionsPharos
+	DeviceOptionsPharos,
+	Mappings
 } from '../types/src'
 
 import { TimelineState, ResolvedTimelineObjectInstance } from 'superfly-timeline'
@@ -47,7 +48,7 @@ type CommandContext = string
  * This is a wrapper for a Pharos-devices,
  * https://www.pharoscontrols.com/downloads/documentation/application-notes/
  */
-export class PharosDevice extends DeviceWithState<TimelineState> implements IDevice {
+export class PharosDevice extends DeviceWithState<PharosState> implements IDevice {
 	private _doOnTime: DoOnTime
 
 	private _pharos: Pharos
@@ -105,13 +106,13 @@ export class PharosDevice extends DeviceWithState<TimelineState> implements IDev
 	 * in time.
 	 * @param newState
 	 */
-	handleState (newState: TimelineState) {
+	handleState (newState: TimelineState, newMappings: Mappings) {
+		super.onHandleState(newState, newMappings)
 		// Handle this new state, at the point in time specified
 
 		let previousStateTime = Math.max(this.getCurrentTime(), newState.time)
-		let oldState: TimelineState = (this.getStateBefore(previousStateTime) || { state: { time: 0, layers: {}, nextEvents: [] } }).state
+		let oldPharosState: PharosState = (this.getStateBefore(previousStateTime) || { state: { Layers: {}, time: 0, layers: {}, nextEvents: [] } }).state
 
-		let oldPharosState = this.convertStateToPharos(oldState)
 		let newPharosState = this.convertStateToPharos(newState)
 
 		let commandsToAchieveState: Array<Command> = this._diffStates(oldPharosState, newPharosState)
@@ -122,7 +123,7 @@ export class PharosDevice extends DeviceWithState<TimelineState> implements IDev
 		this._addToQueue(commandsToAchieveState, newState.time)
 
 		// store the new state, for later use:
-		this.setState(newState, newState.time)
+		this.setState(newPharosState, newState.time)
 	}
 	clearFuture (clearAfterTime: number) {
 		// Clear any scheduled commands after this time

--- a/src/devices/singularLive.ts
+++ b/src/devices/singularLive.ts
@@ -15,7 +15,8 @@ import {
 	TimelineObjSingularLiveAny,
 	DeviceOptionsSingularLive,
 	SingularCompositionAnimation,
-	SingularCompositionControlNode
+	SingularCompositionControlNode,
+	Mappings
 } from '../types/src'
 import { DoOnTime, SendMode } from '../doOnTime'
 import * as request from 'request'
@@ -74,7 +75,7 @@ const SINGULAR_LIVE_API = 'https://app.singular.live/apiv1/control/'
 /**
  * This is a Singular.Live device, it talks to a Singular.Live App Instance using an Access Token
  */
-export class SingularLiveDevice extends DeviceWithState<TimelineState> implements IDevice {
+export class SingularLiveDevice extends DeviceWithState<SingularLiveState> implements IDevice {
 
 	// private _makeReadyCommands: SingularLiveCommandContent[]
 	private _accessToken: string
@@ -111,16 +112,16 @@ export class SingularLiveDevice extends DeviceWithState<TimelineState> implement
 		this._doOnTime.clearQueueNowAndAfter(newStateTime)
 		this.cleanUpStates(0, newStateTime)
 	}
-	handleState (newState: TimelineState) {
+	handleState (newState: TimelineState, newMappings: Mappings) {
+		super.onHandleState(newState, newMappings)
 		// Handle this new state, at the point in time specified
 
 		let previousStateTime = Math.max(this.getCurrentTime(), newState.time)
-		let oldState: TimelineState = (this.getStateBefore(previousStateTime) || { state: { time: 0, layers: {}, nextEvents: [] } }).state
+		let oldSingularState: SingularLiveState = (this.getStateBefore(previousStateTime) || { state: { compositions: {} } }).state
 
-		let oldAbstractState = this.convertStateToSingularLive(oldState)
-		let newAbstractState = this.convertStateToSingularLive(newState)
+		let newSingularState = this.convertStateToSingularLive(newState, newMappings)
 
-		let commandsToAchieveState: Array<any> = this._diffStates(oldAbstractState, newAbstractState)
+		let commandsToAchieveState: Array<any> = this._diffStates(oldSingularState, newSingularState)
 
 		// clear any queued commands later than this time:
 		this._doOnTime.clearQueueNowAndAfter(previousStateTime)
@@ -128,7 +129,7 @@ export class SingularLiveDevice extends DeviceWithState<TimelineState> implement
 		this._addToQueue(commandsToAchieveState, newState.time)
 
 		// store the new state, for later use:
-		this.setState(newState, newState.time)
+		this.setState(newSingularState, newState.time)
 	}
 	clearFuture (clearAfterTime: number) {
 		// Clear any scheduled commands after this time
@@ -165,13 +166,13 @@ export class SingularLiveDevice extends DeviceWithState<TimelineState> implement
 			compositions: {}
 		}
 	}
-	convertStateToSingularLive (state: TimelineState) {
+	convertStateToSingularLive (state: TimelineState, newMappings: Mappings) {
 		// convert the timeline state into something we can use
 		// (won't even use this.mapping)
 		const singularState: SingularLiveState = this._getDefaultState()
 
 		_.each(state.layers, (tlObject: ResolvedTimelineObjectInstance, layerName: string) => {
-			const mapping: MappingSingularLive | undefined = this.getMapping()[layerName] as MappingSingularLive
+			const mapping: MappingSingularLive | undefined = newMappings[layerName] as MappingSingularLive
 			if (mapping && mapping.device === DeviceType.SINGULAR_LIVE && mapping.deviceId === this.deviceId) {
 				let tlObjectSource = tlObject as any as TimelineObjSingularLiveAny
 

--- a/src/devices/sisyfos.ts
+++ b/src/devices/sisyfos.ts
@@ -8,7 +8,8 @@ import {
 } from './device'
 import {
 	DeviceType,
-	DeviceOptionsSisyfos
+	DeviceOptionsSisyfos,
+	Mappings
 } from '../types/src'
 import { DoOnTime, SendMode } from '../doOnTime'
 
@@ -103,7 +104,8 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 	 * in time.
 	 * @param newState
 	 */
-	handleState (newState: TimelineState) {
+	handleState (newState: TimelineState, newMappings: Mappings) {
+		super.onHandleState(newState, newMappings)
 		if (!this._sisyfos.state) {
 			this.emit('warning', 'Sisyfos State not initialized yet')
 			return
@@ -111,16 +113,16 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 
 		// Transform timeline states into device states
 		let previousStateTime = Math.max(this.getCurrentTime(), newState.time)
-		let oldState: SisyfosState = (this.getStateBefore(previousStateTime) || { state: { channels: {}, resync: false } }).state
+		let oldSisyfosState: SisyfosState = (this.getStateBefore(previousStateTime) || { state: { channels: {}, resync: false } }).state
 
-		let newAbstractState = this.convertStateToSisyfosState(newState)
+		let newSisyfosState = this.convertStateToSisyfosState(newState, newMappings)
 
-		this._handleStateInner(oldState, newAbstractState, previousStateTime, newState.time)
+		this._handleStateInner(oldSisyfosState, newSisyfosState, previousStateTime, newState.time)
 	}
 
-	private _handleStateInner (oldState: SisyfosState, newAbstractState: SisyfosState, previousStateTime: number, newTime: number) {
+	private _handleStateInner (oldSisyfosState: SisyfosState, newSisyfosState: SisyfosState, previousStateTime: number, newTime: number) {
 		// Generate commands necessary to transition to the new state
-		let commandsToAchieveState: Array<Command> = this._diffStates(oldState, newAbstractState)
+		let commandsToAchieveState: Array<Command> = this._diffStates(oldSisyfosState, newSisyfosState)
 
 		// clear any queued commands later than this time:
 		this._doOnTime.clearQueueNowAndAfter(previousStateTime)
@@ -128,7 +130,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 		this._addToQueue(commandsToAchieveState, newTime)
 
 		// store the new state, for later use:
-		this.setState(newAbstractState, newTime)
+		this.setState(newSisyfosState, newTime)
 	}
 
 	/**
@@ -247,10 +249,9 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 	 * a timeline state.
 	 * @param state
 	 */
-	convertStateToSisyfosState (state: TimelineState) {
+	convertStateToSisyfosState (state: TimelineState, mappings: Mappings) {
 		const deviceState: SisyfosState = this.getDeviceState()
 
-		const mappings = this.getMapping()
 		_.each(state.layers, (tlObject, layerName) => {
 			const layer = tlObject as ResolvedTimelineObjectInstance & TimelineObjSisyfosAny
 			let foundMapping = mappings[layerName] as MappingSisyfos | undefined

--- a/src/devices/tcpSend.ts
+++ b/src/devices/tcpSend.ts
@@ -11,7 +11,8 @@ import {
 	DeviceType,
 	TCPSendOptions,
 	TcpSendCommandContent,
-	DeviceOptionsTCPSend
+	DeviceOptionsTCPSend,
+	Mappings
 } from '../types/src'
 import { DoOnTime, SendMode } from '../doOnTime'
 import {
@@ -36,10 +37,12 @@ interface TCPSendCommand {
 }
 type CommandContext = string
 
+type TSCSendState = TimelineState
+
 /**
  * This is a TCPSendDevice, it sends commands over tcp when it feels like it
  */
-export class TCPSendDevice extends DeviceWithState<TimelineState> implements IDevice {
+export class TCPSendDevice extends DeviceWithState<TSCSendState> implements IDevice {
 
 	private _makeReadyCommands: TcpSendCommandContent[]
 	private _makeReadyDoesReset: boolean
@@ -86,16 +89,16 @@ export class TCPSendDevice extends DeviceWithState<TimelineState> implements IDe
 		this._doOnTime.clearQueueNowAndAfter(newStateTime)
 		this.cleanUpStates(0, newStateTime)
 	}
-	handleState (newState: TimelineState) {
+	handleState (newState: TimelineState, newMappings: Mappings) {
+		super.onHandleState(newState, newMappings)
 		// Handle this new state, at the point in time specified
 
 		let previousStateTime = Math.max(this.getCurrentTime(), newState.time)
-		let oldState: TimelineState = (this.getStateBefore(previousStateTime) || { state: { time: 0, layers: {}, nextEvents: [] } }).state
+		let oldTCPSendState: TSCSendState = (this.getStateBefore(previousStateTime) || { state: { time: 0, layers: {}, nextEvents: [] } }).state
 
-		let oldAbstractState = this.convertStateToTCPSend(oldState)
-		let newAbstractState = this.convertStateToTCPSend(newState)
+		let newTCPSendState = this.convertStateToTCPSend(newState)
 
-		let commandsToAchieveState: Array<any> = this._diffStates(oldAbstractState, newAbstractState)
+		let commandsToAchieveState: Array<any> = this._diffStates(oldTCPSendState, newTCPSendState)
 
 		// clear any queued commands later than this time:
 		this._doOnTime.clearQueueNowAndAfter(previousStateTime)

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -22,7 +22,8 @@ import {
 	DeviceOptionsVizMSE,
 	TimelineObjVIZMSEAny,
 	VIZMSEOutTransition,
-	VIZMSETransitionType
+	VIZMSETransitionType,
+	Mappings
 } from '../types/src'
 
 import {
@@ -161,7 +162,8 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 	/**
 	 * Generates an array of VizMSE commands by comparing the newState against the oldState, or the current device state.
 	 */
-	handleState (newState: TimelineState) {
+	handleState (newState: TimelineState, newMappings: Mappings) {
+		super.onHandleState(newState, newMappings)
 		// check if initialized:
 		if (!this._vizmseManager || !this._vizmseManager.initialized) {
 			this.emit('warning', 'VizMSE.v-connection not initialized yet')
@@ -175,7 +177,7 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 			{ state: { time: 0, layer: {} } }
 		).state
 
-		let newVizMSEState = this.convertStateToVizMSE(newState)
+		let newVizMSEState = this.convertStateToVizMSE(newState, newMappings)
 
 		let commandsToAchieveState = this._diffStates(oldVizMSEState, newVizMSEState, newState.time)
 
@@ -236,14 +238,12 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 	 * Takes a timeline state and returns a VizMSE State that will work with the state lib.
 	 * @param timelineState The timeline state to generate from.
 	 */
-	convertStateToVizMSE (timelineState: TimelineState): VizMSEState {
+	convertStateToVizMSE (timelineState: TimelineState, mappings: Mappings): VizMSEState {
 
 		const state: VizMSEState = {
 			time: timelineState.time,
 			layer: {}
 		}
-
-		const mappings = this.getMapping()
 
 		_.each(timelineState.layers, (layer: ResolvedTimelineObjectInstance, layerName: string) => {
 


### PR DESCRIPTION
Treat Mappings as dynamic data, the same way we do with timeline.

This is a rather large "bug fix", ended up causing breaking changes due to its nature.
The Problem: When setting new Mappings, TSR was not able to react to these changes properly (resolving timeline, sending new commands, etc).

* Timeline and Mappings are now updated in the same method.
* Devices use their own state, not the generic TimelineState (this is to avoid mixing old-state with new mappings).
* Devices now receive the mappings in handleState, not internally stored as before

Co-authored-by: Balte de Wit <balte.dewit@gmail.com>