### PR TITLE
Feat: casparcg ffmpeg filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,8 +160,8 @@
   "dependencies": {
     "atem-state": "^0.10.0",
     "bufferutil": "^4.0.1",
-    "casparcg-connection": "^5.0.1",
-    "casparcg-state": "^2.0.0",
+    "casparcg-connection": "5.1.0-nightly-feat-ffmpeg-filters-20201021-124046-7bc1e6ea.0",
+    "casparcg-state": "2.1.0-nightly-feat-filters-20201021-125451-f737f4b.0",
     "emberplus-connection": "^0.0.3",
     "hyperdeck-connection": "^0.4.3",
     "osc": "^2.4.0",

--- a/src/devices/__tests__/casparcg.spec.ts
+++ b/src/devices/__tests__/casparcg.spec.ts
@@ -35,17 +35,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -120,17 +120,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -193,17 +193,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -277,17 +277,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -350,17 +350,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -438,17 +438,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -522,17 +522,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -600,24 +600,24 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping1: MappingCasparCG = {
+		const myLayerMapping1: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 1,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0,
 			'myLayer1': myLayerMapping1
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -721,17 +721,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -826,17 +826,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -963,17 +963,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -1070,18 +1070,18 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42,
 			previewWhenNotOnAir: true
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -1177,17 +1177,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -1291,17 +1291,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 1,
 			layer: 10
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -1381,17 +1381,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -1470,17 +1470,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})
@@ -1615,17 +1615,17 @@ describe('CasparCG', () => {
 		const commandReceiver0: any = jest.fn(() => {
 			return Promise.resolve()
 		})
-		let myLayerMapping0: MappingCasparCG = {
+		const myLayerMapping0: MappingCasparCG = {
 			device: DeviceType.CASPARCG,
 			deviceId: 'myCCG',
 			channel: 2,
 			layer: 42
 		}
-		let myLayerMapping: Mappings = {
+		const myLayerMapping: Mappings = {
 			'myLayer0': myLayerMapping0
 		}
 
-		let myConductor = new Conductor({
+		const myConductor = new Conductor({
 			initializeAsClear: true,
 			getCurrentTime: mockTime.getCurrentTime
 		})

--- a/src/devices/casparCG.ts
+++ b/src/devices/casparCG.ts
@@ -288,8 +288,12 @@ export class CasparCGDevice extends DeviceWithState<State> implements IDevice {
 				length:			mediaObj.content.length,
 
 				channelLayout:	mediaObj.content.channelLayout,
-				clearOn404: 	true
+				clearOn404: 	true,
+
+				vfilter:		mediaObj.content.videoFilter,
+				afilter:		mediaObj.content.audioFilter
 			})
+			// this.emit('debug', stateLayer)
 		} else if (layer.content.type === TimelineContentTypeCasparCg.IP) {
 
 			const ipObj = layer as any as TimelineObjCCGIP
@@ -302,7 +306,10 @@ export class CasparCGDevice extends DeviceWithState<State> implements IDevice {
 				channelLayout:	ipObj.content.channelLayout,
 				playTime:		null, // ip inputs can't be seeked // layer.resolved.startTime || null,
 				playing:		true,
-				seek:			0 // ip inputs can't be seeked
+				seek:			0, // ip inputs can't be seeked
+
+				vfilter:		ipObj.content.videoFilter,
+				afilter:		ipObj.content.audioFilter
 			})
 		} else if (layer.content.type === TimelineContentTypeCasparCg.INPUT) {
 			const inputObj = layer as any as TimelineObjCCGInput
@@ -319,7 +326,10 @@ export class CasparCGDevice extends DeviceWithState<State> implements IDevice {
 				},
 				filter: 		inputObj.content.filter,
 				playing:		true,
-				playTime:		null
+				playTime:		null,
+
+				vfilter:		inputObj.content.videoFilter,
+				afilter:		inputObj.content.audioFilter
 			})
 		} else if (layer.content.type === TimelineContentTypeCasparCg.TEMPLATE) {
 			const recordObj = layer as any as TimelineObjCCGTemplate
@@ -372,7 +382,10 @@ export class CasparCGDevice extends DeviceWithState<State> implements IDevice {
 				mode:			routeObj.content.mode || undefined,
 				delay:			routeObj.content.delay || undefined,
 				playing:		true,
-				playTime:		null // layer.resolved.startTime || null,
+				playTime:		null, // layer.resolved.startTime || null,
+
+				vfilter:		routeObj.content.videoFilter,
+				afilter:		routeObj.content.audioFilter
 			})
 		} else if (layer.content.type === TimelineContentTypeCasparCg.RECORD) {
 			const recordObj = layer as any as TimelineObjCCGRecord

--- a/src/types/src/casparcg.ts
+++ b/src/types/src/casparcg.ts
@@ -114,6 +114,10 @@ export interface TimelineObjCCGMedia extends TimelineObjCasparCGBase {
 
 		/** If true, the startTime won't be used to SEEK to the correct place in the media */
 		noStarttime?: boolean
+
+		/* ffmpeg filter strings for 2.3+ */
+		videoFilter?: string
+		audioFilter?: string
 	} & TimelineObjCCGProducerContentBase
 }
 export interface TimelineObjCCGIP extends TimelineObjCasparCGBase {
@@ -127,6 +131,10 @@ export interface TimelineObjCCGIP extends TimelineObjCasparCGBase {
 		// audioFilter?: string
 		/** Audio channel layout (example 'stereo') */
 		channelLayout?: string
+
+		/* ffmpeg filter strings for 2.3+ */
+		videoFilter?: string
+		audioFilter?: string
 	} & TimelineObjCCGProducerContentBase
 }
 export interface TimelineObjCCGInput extends TimelineObjCasparCGBase {
@@ -146,6 +154,10 @@ export interface TimelineObjCCGInput extends TimelineObjCasparCGBase {
 
 		/** Audio channel layout (example 'stereo') */
 		channelLayout?: string
+
+		/* ffmpeg filter strings for 2.3+ */
+		videoFilter?: string
+		audioFilter?: string
 	} & TimelineObjCCGProducerContentBase
 }
 export interface TimelineObjCCGHTMLPage extends TimelineObjCasparCGBase {
@@ -188,6 +200,10 @@ export interface TimelineObjCCGRoute extends TimelineObjCasparCGBase {
 		channelLayout?: string
 		/** The amount of milliseconds to delay the signal on this route. This value is downsampled to channel frames upon execution. */
 		delay?: number
+
+		/* ffmpeg filter strings for 2.3+ */
+		videoFilter?: string
+		audioFilter?: string
 	} & TimelineObjCCGProducerContentBase
 }
 export interface TimelineObjCCGRecord extends TimelineObjCasparCGBase {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1432,21 +1432,21 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-casparcg-connection@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/casparcg-connection/-/casparcg-connection-5.0.1.tgz#5144f43664586ec2b73fc380f893b63704fc46e0"
-  integrity sha512-gurGsJozCeBVuW2rPnttBj3WS4HJxW3RXC4x2OINdcs+rwAJRKy5tBg2MilsRp2Hh+wQL/e/16ZTjpCkvvkG5A==
+casparcg-connection@5.1.0-nightly-feat-ffmpeg-filters-20201021-124046-7bc1e6ea.0:
+  version "5.1.0-nightly-feat-ffmpeg-filters-20201021-124046-7bc1e6ea.0"
+  resolved "https://registry.yarnpkg.com/casparcg-connection/-/casparcg-connection-5.1.0-nightly-feat-ffmpeg-filters-20201021-124046-7bc1e6ea.0.tgz#c0368eb0302b6896df0853437753aa79d440d31c"
+  integrity sha512-39TuQ/AgSGMiwAZvdTj2Kj/Zy/Qbej+73JZccVcBexDwsOrdd6T0ke7WDdwARfZZVI27fx/nl7nWL/Gc+2UJXg==
   dependencies:
     highland "^3.0.0-beta.6"
     xml2js "^0.4.19"
     xmlbuilder "^9.0.7"
 
-casparcg-state@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/casparcg-state/-/casparcg-state-2.0.0.tgz#1ce38ff1846a259de4bc4fe706a312849539b34e"
-  integrity sha512-eZ0f8PWkxk3t/xgUaE1i4wqpHFNEeMBPs8L4mCoTFg3MdfqPVUg/bW6XZPFcPFOruQ93UekaTUpKKDafsASYsg==
+casparcg-state@2.1.0-nightly-feat-filters-20201021-125451-f737f4b.0:
+  version "2.1.0-nightly-feat-filters-20201021-125451-f737f4b.0"
+  resolved "https://registry.yarnpkg.com/casparcg-state/-/casparcg-state-2.1.0-nightly-feat-filters-20201021-125451-f737f4b.0.tgz#9d6b490c37e32b6c4b9cfd084927c65acaeada4b"
+  integrity sha512-JynIj9BFSqf9j6l2uHjGuoejhEQdD9UU+zvR2Vo/r8eqC3k7/kOi3U+PbOoYnJq2U6nIk3jkuC94CJlCKtGveQ==
   dependencies:
-    casparcg-connection "^5.0.1"
+    casparcg-connection "5.1.0-nightly-feat-ffmpeg-filters-20201021-124046-7bc1e6ea.0"
     fast-clone "^1.5.13"
     underscore "^1.9.1"
 


### PR DESCRIPTION
This PR introduces video and audio filters to the CasparCG implemenation for use with CasparCG 2.3.

_Note that this PR is a based on https://github.com/nrkno/tv-automation-state-timeline-resolver/pull/168, which has its own review process_