### PR TITLE
fix: better info and warnings for quantel issues

### DIFF
--- a/src/devices/quantel.ts
+++ b/src/devices/quantel.ts
@@ -84,8 +84,8 @@ export class QuantelDevice extends DeviceWithState<QuantelState> implements IDev
 			}
 		)
 		this._quantelManager.on('info', str => this.emit('info', 'Quantel: ' + str))
-		this._quantelManager.on('warning', str => this.emit('warning', 'Quantel' + str))
-		this._quantelManager.on('error', e => this.emit('error', 'Quantel', e))
+		this._quantelManager.on('warning', x => this.emit('warning', `Quantel: ${typeof x === 'string' ? x : JSON.stringify(x)}`))
+		this._quantelManager.on('error', e => this.emit('error', 'Quantel: ', e))
 		this._quantelManager.on('debug', (...args) => this.emit('debug', ...args))
 
 		this._doOnTime = new DoOnTime(() => {

--- a/src/devices/quantel.ts
+++ b/src/devices/quantel.ts
@@ -83,7 +83,7 @@ export class QuantelDevice extends DeviceWithState<QuantelState> implements IDev
 				allowCloneClips: deviceOptions.options.allowCloneClips
 			}
 		)
-		this._quantelManager.on('info', str => this.emit('info', 'Quantel: ' + str))
+		this._quantelManager.on('info', x => this.emit('info',`Quantel: ${typeof x === 'string' ? x : JSON.stringify(x)}`))
 		this._quantelManager.on('warning', x => this.emit('warning', `Quantel: ${typeof x === 'string' ? x : JSON.stringify(x)}`))
 		this._quantelManager.on('error', e => this.emit('error', 'Quantel: ', e))
 		this._quantelManager.on('debug', (...args) => this.emit('debug', ...args))


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

A fix to warning messages logged when a Quantel port does not play. 

* **What is the current behavior?** (You can also link to an open issue here)

Logs `Quantel[object Object]` and `QuantelquantelRecovery: port didn't play` - sort of ugly and not useful.

* **What is the new behavior (if this is a feature change)?**

Should now log `Quantel: { ... details }` and `Quantel: quantelRecovery: port didn't play`.

* **Other information**:

Turns out this was a symptom of a playout issue, not the cause. Having more information in this log will speed up future analysis.
