### PR TITLE
feat: add support for advanced settings in the TimelineObjAtemSsrcProps

### DIFF
--- a/src/types/src/atem.ts
+++ b/src/types/src/atem.ts
@@ -292,7 +292,7 @@ interface AtemSSrcPropsBorder {
 	/** Enable borders on boxes */
 	borderEnabled?: true
 	/** Border Bevel mode:
-	 * 0: no bevel, 1: in/out, 2: in, 3: out */
+	  * 0: no bevel, 1: in/out, 2: in, 3: out */
 	borderBevel: number
 	/** Width of the outer side of the bevel, 0-1600 */
 	borderOuterWidth: number

--- a/src/types/src/atem.ts
+++ b/src/types/src/atem.ts
@@ -262,30 +262,47 @@ export interface TimelineObjAtemSsrcProps extends TimelineObjAtemBase {
 		deviceType: DeviceType.ATEM
 		type: TimelineContentTypeAtem.SSRCPROPS
 		ssrcProps: {
-			/** Fill */
+			/** Fill source */
 			artFillSource: number
-			/** Key */
+			/** Key source */
 			artCutSource: number
-			/** Foreground */
+			/** 0: Art Source in background, 1: Art Source in foreground */
 			artOption: number
-			/** Premultiply key */
+			/** Premultiply key for Art Source */
 			artPreMultiplied: boolean
-			// artClip: number
-			// artGain: number
-			// artInvertKey: number
-			// borderEnabled: number
-			// borderBevel: number
-			// borderOuterWidth: number
-			// borderInnerWidth: number
-			// borderOuterSoftness: number
-			// borderInnerSoftness: number
-			// borderBevelSoftness: number
-			// borderBevelPosition: number
-			// borderHue: number
-			// borderSaturation: number
-			// borderLuma: number
-			// borderLightSourceDirection: number
-			// borderLightSourceAltitude: number
+			/** Linear keyer Clip value for Art Source, 0-1000 */
+			artClip: number
+			/** Linear keyer Gain value for Art Source, 0-1000  */
+			artGain: number
+			/** Invert keyer Key input */
+			artInvertKey: boolean
+			/** Enable borders on boxes */
+			borderEnabled: boolean
+			/** Border Bevel mode:
+			 * 0: no bevel, 1: in/out, 2: in, 3: out */
+			borderBevel: number
+			/** Width of the outer side of the bevel, 0-1600 */
+			borderOuterWidth: number
+			/** Width of the inner side of the bevel, 0-1600 */
+			borderInnerWidth: number
+			/** Softness of the outer side of the bevel, 0-100 */
+			borderOuterSoftness: number
+			/** Softness of the inner side of the bevel, 0-100 */
+			borderInnerSoftness: number
+			/** Softness of the bevel, 0-100 */
+			borderBevelSoftness: number
+			/** Position of the bevel, 0-100 */
+			borderBevelPosition: number
+			/** Hue of the border color, 0-3599 */
+			borderHue: number
+			/** Saturation of the border color, 0-1000 */
+			borderSaturation: number
+			/** Luminance of the border color, 0-1000 */
+			borderLuma: number
+			/** Light source direction for rendering the bevel, 0-3590 */
+			borderLightSourceDirection: number
+			/** Light source altitude for rendering the bevel, 10-100 */
+			borderLightSourceAltitude: number
 		}
 	}
 }

--- a/src/types/src/atem.ts
+++ b/src/types/src/atem.ts
@@ -257,55 +257,75 @@ export interface TimelineObjAtemSsrc extends TimelineObjAtemBase {
 		}
 	}
 }
+
+interface AtemSSrcPropsBase {
+	/** Fill source */
+	artFillSource: number
+	/** Key source */
+	artCutSource: number
+	/** 0: Art Source in background, 1: Art Source in foreground */
+	artOption: number
+}
+
+interface AtemSSrcPropsPreMultiplied extends AtemSSrcPropsBase {
+	/** Premultiply key for Art Source */
+	artPreMultiplied: true
+}
+
+interface AtemSSrcPropsStraight extends AtemSSrcPropsBase {
+	/** Premultiply key for Art Source */
+	artPreMultiplied: false
+	/** Linear keyer Clip value for Art Source, 0-1000 */
+	artClip: number
+	/** Linear keyer Gain value for Art Source, 0-1000  */
+	artGain: number
+	/** Invert keyer Key input */
+	artInvertKey: boolean
+}
+
+interface AtemSSrcPropsNoBorder {
+	/** Enable borders on boxes */
+	borderEnabled?: false
+}
+
+interface AtemSSrcPropsBorder {
+	/** Enable borders on boxes */
+	borderEnabled?: true
+	/** Border Bevel mode:
+	 * 0: no bevel, 1: in/out, 2: in, 3: out */
+	borderBevel: number
+	/** Width of the outer side of the bevel, 0-1600 */
+	borderOuterWidth: number
+	/** Width of the inner side of the bevel, 0-1600 */
+	borderInnerWidth: number
+	/** Softness of the outer side of the bevel, 0-100 */
+	borderOuterSoftness: number
+	/** Softness of the inner side of the bevel, 0-100 */
+	borderInnerSoftness: number
+	/** Softness of the bevel, 0-100 */
+	borderBevelSoftness: number
+	/** Position of the bevel, 0-100 */
+	borderBevelPosition: number
+	/** Hue of the border color, 0-3599 */
+	borderHue: number
+	/** Saturation of the border color, 0-1000 */
+	borderSaturation: number
+	/** Luminance of the border color, 0-1000 */
+	borderLuma: number
+	/** Light source direction for rendering the bevel, 0-3590 */
+	borderLightSourceDirection: number
+	/** Light source altitude for rendering the bevel, 10-100 */
+	borderLightSourceAltitude: number
+}
+
 export interface TimelineObjAtemSsrcProps extends TimelineObjAtemBase {
 	content: {
 		deviceType: DeviceType.ATEM
 		type: TimelineContentTypeAtem.SSRCPROPS
-		ssrcProps: {
-			/** Fill source */
-			artFillSource: number
-			/** Key source */
-			artCutSource: number
-			/** 0: Art Source in background, 1: Art Source in foreground */
-			artOption: number
-			/** Premultiply key for Art Source */
-			artPreMultiplied: boolean
-			/** Linear keyer Clip value for Art Source, 0-1000 */
-			artClip: number
-			/** Linear keyer Gain value for Art Source, 0-1000  */
-			artGain: number
-			/** Invert keyer Key input */
-			artInvertKey: boolean
-			/** Enable borders on boxes */
-			borderEnabled: boolean
-			/** Border Bevel mode:
-			 * 0: no bevel, 1: in/out, 2: in, 3: out */
-			borderBevel: number
-			/** Width of the outer side of the bevel, 0-1600 */
-			borderOuterWidth: number
-			/** Width of the inner side of the bevel, 0-1600 */
-			borderInnerWidth: number
-			/** Softness of the outer side of the bevel, 0-100 */
-			borderOuterSoftness: number
-			/** Softness of the inner side of the bevel, 0-100 */
-			borderInnerSoftness: number
-			/** Softness of the bevel, 0-100 */
-			borderBevelSoftness: number
-			/** Position of the bevel, 0-100 */
-			borderBevelPosition: number
-			/** Hue of the border color, 0-3599 */
-			borderHue: number
-			/** Saturation of the border color, 0-1000 */
-			borderSaturation: number
-			/** Luminance of the border color, 0-1000 */
-			borderLuma: number
-			/** Light source direction for rendering the bevel, 0-3590 */
-			borderLightSourceDirection: number
-			/** Light source altitude for rendering the bevel, 10-100 */
-			borderLightSourceAltitude: number
-		}
+		ssrcProps: (AtemSSrcPropsPreMultiplied | AtemSSrcPropsStraight) & (AtemSSrcPropsNoBorder | AtemSSrcPropsBorder)
 	}
 }
+
 export interface TimelineObjAtemMediaPlayer extends TimelineObjAtemBase {
 	content: {
 		deviceType: DeviceType.ATEM

--- a/src/types/src/atem.ts
+++ b/src/types/src/atem.ts
@@ -292,7 +292,8 @@ interface AtemSSrcPropsBorder {
 	/** Enable borders on boxes */
 	borderEnabled?: true
 	/** Border Bevel mode:
-	  * 0: no bevel, 1: in/out, 2: in, 3: out */
+	 *  0: no bevel, 1: in/out, 2: in, 3: out
+	 */
 	borderBevel: number
 	/** Width of the outer side of the bevel, 0-1600 */
 	borderOuterWidth: number


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds support for advanced SuperSource parameters in the `TimelineObjAtemSsrcProps` object.

* **What is the current behavior?** (You can also link to an open issue here)

These properties aren't typed in TSR, but TSR will forward them, if present in a Timeline Object.

* **What is the new behavior (if this is a feature change)?**

The properties are specified on the interface. Associated properties are required when key flags are turned on. This enables backwards-compatibility when using `artPreMultiplied: true`, while enforcing the keying properties and border properties in when their respective flags are turned on.

* **Other information**:
