### PR TITLE
fix(sisyfos): retrigger only channels that are mapped in Sofie

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "bufferutil": "^4.0.1",
     "casparcg-connection": "^5.1.0",
     "casparcg-state": "^2.1.0",
+    "debug": "^4.3.1",
     "emberplus-connection": "^0.0.3",
     "hyperdeck-connection": "^0.4.3",
     "osc": "^2.4.0",

--- a/src/devices/__tests__/sisyfos.spec.ts
+++ b/src/devices/__tests__/sisyfos.spec.ts
@@ -724,11 +724,16 @@ describe('Sisyfos', () => {
 
 		// baseline:
 		await mockTime.advanceTimeTicks(100) // 100
-		expect(commandReceiver0.mock.calls.length).toEqual(1)
+		expect(commandReceiver0.mock.calls.length).toEqual(2)
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			type: 'setFader',
 			channel: 1,
 			value: 0.1
+		})
+		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
+			type: 'setFader',
+			channel: 2,
+			value: 0.2
 		})
 		commandReceiver0.mockClear()
 
@@ -903,15 +908,8 @@ describe('Sisyfos', () => {
 
 		// baseline:
 		await mockTime.advanceTimeTicks(100) // 100
-		expect(commandReceiver0.mock.calls.length).toEqual(3)
+		expect(commandReceiver0.mock.calls.length).toEqual(2)
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
-			type: 'setChannel',
-			channel: 0,
-			values: {
-				faderLevel: 0.75
-			}
-		})
-		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
 			type: 'setChannel',
 			channel: 1,
 			values: {
@@ -919,7 +917,7 @@ describe('Sisyfos', () => {
 				pgmOn: 0
 			}
 		})
-		expect(getMockCall(commandReceiver0, 2, 1)).toMatchObject({
+		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
 			type: 'setChannel',
 			channel: 2,
 			values: {
@@ -931,15 +929,8 @@ describe('Sisyfos', () => {
 
 		// obj1 has started
 		await mockTime.advanceTimeTicks(1000) // 1100
-		expect(commandReceiver0.mock.calls.length).toEqual(3)
+		expect(commandReceiver0.mock.calls.length).toEqual(2)
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
-			type: 'setChannel',
-			channel: 0,
-			values: {
-				faderLevel: 0.75
-			}
-		})
-		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
 			type: 'setChannel',
 			channel: 1,
 			values: {
@@ -947,7 +938,7 @@ describe('Sisyfos', () => {
 				pgmOn: 0
 			}
 		})
-		expect(getMockCall(commandReceiver0, 2, 1)).toMatchObject({
+		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
 			type: 'setChannel',
 			channel: 2,
 			values: {
@@ -959,15 +950,8 @@ describe('Sisyfos', () => {
 
 		// back to baseline
 		await mockTime.advanceTimeTicks(10000) // 11100
-		expect(commandReceiver0.mock.calls.length).toEqual(3)
+		expect(commandReceiver0.mock.calls.length).toEqual(2)
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
-			type: 'setChannel',
-			channel: 0,
-			values: {
-				faderLevel: 0.75
-			}
-		})
-		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
 			type: 'setChannel',
 			channel: 1,
 			values: {
@@ -975,7 +959,7 @@ describe('Sisyfos', () => {
 				pgmOn: 0
 			}
 		})
-		expect(getMockCall(commandReceiver0, 2, 1)).toMatchObject({
+		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
 			type: 'setChannel',
 			channel: 2,
 			values: {

--- a/src/devices/sisyfos.ts
+++ b/src/devices/sisyfos.ts
@@ -33,7 +33,7 @@ import {
 	SisyfosChannel,
 	SisyfosCommandType
 } from './sisyfosAPI'
-import Debug from "debug"
+import Debug from 'debug'
 const debug = Debug('timeline-state-resolver:sisyfos')
 
 export interface DeviceOptionsSisyfosInternal extends DeviceOptionsSisyfos {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1968,6 +1968,13 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
+debug@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"


### PR DESCRIPTION
Sisyfos retrigger mechanism was triggering commands for every channel exposed in Sisyfos, which meant that it touched channels that were not supposed to be automated at all. This PR changes the default state to only include channels that are in the Sofie mappings such that no commands will be sent for channels that are not mapped.