### PR TITLE
Fix: Quantel reload fragments if not found

### DIFF
--- a/src/devices/__tests__/quantel.spec.ts
+++ b/src/devices/__tests__/quantel.spec.ts
@@ -1352,7 +1352,7 @@ describe('Quantel', () => {
 			myConductor
 		} = await setupDefaultQuantelDeviceForTest()
 
-		quantelServer.noClipsFond = true
+		quantelServer.noClipsFound = true
 
 		myConductor.setTimelineAndMappings([
 			{
@@ -1400,7 +1400,7 @@ describe('Quantel', () => {
 
 		clearMocks()
 		commandReceiver0.mockClear()
-		quantelServer.noClipsFond = false
+		quantelServer.noClipsFound = false
 		await mockTime.advanceTimeTicks(10000)
 
 		expect(onRequest).toHaveBeenCalledTimes(8)

--- a/src/devices/__tests__/quantelGatewayMock.ts
+++ b/src/devices/__tests__/quantelGatewayMock.ts
@@ -14,7 +14,7 @@ export function setupQuantelGatewayMock () {
 		requestReturnsOK: true,
 		ignoreConnectivityCheck: false,
 		ISAOptionHasBeenProvided: false,
-		noClipsFond: false,
+		noClipsFound: false,
 		port: {
 			'my_port': {
 				endOfData: 0,
@@ -72,7 +72,7 @@ interface QuantelServerMockOptions {
 	requestReturnsOK: boolean
 	ignoreConnectivityCheck: boolean
 	ISAOptionHasBeenProvided: boolean
-	noClipsFond: boolean
+	noClipsFound: boolean
 	port: {
 		[port: string]: QuantelServerMockOptionsPort
 	}
@@ -155,7 +155,7 @@ function handleRequest (
 
 			const searchClip = (params): Q.ClipDataSummary[] | ErrorResponse => {
 				if (!quantelServer.ISAOptionHasBeenProvided) return noIsaSetupResponse
-				if (quantelServer.noClipsFond) return []
+				if (quantelServer.noClipsFound) return []
 
 				return _.filter<Q.ClipDataSummary[]>([
 					{

--- a/src/devices/__tests__/quantelGatewayMock.ts
+++ b/src/devices/__tests__/quantelGatewayMock.ts
@@ -14,6 +14,7 @@ export function setupQuantelGatewayMock () {
 		requestReturnsOK: true,
 		ignoreConnectivityCheck: false,
 		ISAOptionHasBeenProvided: false,
+		noClipsFond: false,
 		port: {
 			'my_port': {
 				endOfData: 0,
@@ -71,6 +72,7 @@ interface QuantelServerMockOptions {
 	requestReturnsOK: boolean
 	ignoreConnectivityCheck: boolean
 	ISAOptionHasBeenProvided: boolean
+	noClipsFond: boolean
 	port: {
 		[port: string]: QuantelServerMockOptionsPort
 	}
@@ -153,6 +155,8 @@ function handleRequest (
 
 			const searchClip = (params): Q.ClipDataSummary[] | ErrorResponse => {
 				if (!quantelServer.ISAOptionHasBeenProvided) return noIsaSetupResponse
+				if (quantelServer.noClipsFond) return []
+
 				return _.filter<Q.ClipDataSummary[]>([
 					{
 						type: 'ClipDataSummary',

--- a/src/devices/quantel.ts
+++ b/src/devices/quantel.ts
@@ -741,7 +741,7 @@ class QuantelManager extends EventEmitter {
 
 				this._retryLoadFragmentsTimeout[cmd.portId] = setTimeout(() => {
 					this.tryLoadClipFragments(cmd, true)
-					.catch((err) => this.emit('error', err))
+					.catch((fragErr) => this.emit('error', fragErr))
 				}, 10 * 1000) // 10 seconds
 
 			} else {


### PR DESCRIPTION
This PR adds a retry-logic for the Quantel device, to solve the issue when the Clip doesn't exist in the Quantel-verse at the time of loading of fragments.
