### PR TITLE
feat: Mapping layer name

### DIFF
--- a/src/devices/__tests__/sisyfos.spec.ts
+++ b/src/devices/__tests__/sisyfos.spec.ts
@@ -40,19 +40,22 @@ describe('Sisyfos', () => {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 0
+			channel: 0,
+			setLabelToLayerName: false
 		}
 		let myChannelMapping1: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 1
+			channel: 1,
+			setLabelToLayerName: false
 		}
 		let myChannelMapping2: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 1
+			channel: 1,
+			setLabelToLayerName: false
 		}
 		// @ts-ignore skipping .mappingType to test backwards compatibility
 		let myChannelMapping3: MappingSisyfos = {
@@ -253,25 +256,29 @@ describe('Sisyfos', () => {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 0
+			channel: 0,
+			setLabelToLayerName: false
 		}
 		let myChannelMapping1: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 1
+			channel: 1,
+			setLabelToLayerName: false
 		}
 		let myChannelMapping2: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 1
+			channel: 1,
+			setLabelToLayerName: false
 		}
 		let myChannelMapping3: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 3
+			channel: 3,
+			setLabelToLayerName: false
 		}
 		let myChannelMapping: Mappings = {
 			'sisyfos_channel_1': myChannelMapping0,
@@ -467,25 +474,29 @@ describe('Sisyfos', () => {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 0
+			channel: 0,
+			setLabelToLayerName: false
 		}
 		let myChannelMapping1: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 1
+			channel: 1,
+			setLabelToLayerName: false
 		}
 		let myChannelMapping2: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 1
+			channel: 1,
+			setLabelToLayerName: false
 		}
 		let myChannelMapping3: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 3
+			channel: 3,
+			setLabelToLayerName: false
 		}
 		let myChannelMapping: Mappings = {
 			'sisyfos_channel_1': myChannelMapping0,
@@ -602,13 +613,15 @@ describe('Sisyfos', () => {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 1
+			channel: 1,
+			setLabelToLayerName: false
 		}
 		let myChannelMapping2: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 2
+			channel: 2,
+			setLabelToLayerName: false
 		}
 		let myChannelMapping3: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
@@ -808,13 +821,15 @@ describe('Sisyfos', () => {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 1
+			channel: 1,
+			setLabelToLayerName: false
 		}
 		let myChannelMapping2: MappingSisyfos = {
 			device: DeviceType.SISYFOS,
 			mappingType: MappingSisyfosType.CHANNEL,
 			deviceId: 'mySisyfos',
-			channel: 2
+			channel: 2,
+			setLabelToLayerName: false
 		}
 		let myChannelMapping3: MappingSisyfos = {
 			device: DeviceType.SISYFOS,

--- a/src/devices/sisyfos.ts
+++ b/src/devices/sisyfos.ts
@@ -270,7 +270,6 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 
 			if (!channel) {
 				channel = this.getDefaultStateChannel()
-				
 			}
 
 			channel.label = sisyfosMapping.layerName
@@ -363,7 +362,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 					}
 
 					if (newChannel.faderLevel !== undefined) channel.faderLevel = newChannel.faderLevel
-					if (newChannel.label !== undefined) channel.label = newChannel.label
+					if (newChannel.label !== undefined && newChannel.label !== '') channel.label = newChannel.label
 					if (newChannel.visible !== undefined) channel.visible = newChannel.visible
 
 					channel.tlObjIds.push(tlObject.id)

--- a/src/devices/sisyfos.ts
+++ b/src/devices/sisyfos.ts
@@ -259,6 +259,25 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 	convertStateToSisyfosState (state: TimelineState, mappings: Mappings) {
 		const deviceState: SisyfosState = this.getDeviceState(true, mappings)
 
+		for (const mapping of Object.values(mappings)) {
+			const sisyfosMapping = mapping as MappingSisyfos
+
+			if (sisyfosMapping.mappingType !== MappingSisyfosType.CHANNEL) continue
+
+			if (!sisyfosMapping.layerName) continue
+
+			let channel = deviceState.channels[sisyfosMapping.channel] as SisyfosChannel | undefined
+
+			if (!channel) {
+				channel = this.getDefaultStateChannel()
+				
+			}
+
+			channel.label = sisyfosMapping.layerName
+
+			deviceState.channels[sisyfosMapping.channel] = channel
+		}
+
 		_.each(state.layers, (tlObject, layerName) => {
 			const layer = tlObject as ResolvedTimelineObjectInstance & TimelineObjSisyfosAny
 			let foundMapping = mappings[layerName] as MappingSisyfos | undefined

--- a/src/devices/sisyfos.ts
+++ b/src/devices/sisyfos.ts
@@ -259,10 +259,13 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 	convertStateToSisyfosState (state: TimelineState, mappings: Mappings) {
 		const deviceState: SisyfosState = this.getDeviceState(true, mappings)
 
+		// Set labels to layer names
 		for (const mapping of Object.values(mappings)) {
 			const sisyfosMapping = mapping as MappingSisyfos
 
 			if (sisyfosMapping.mappingType !== MappingSisyfosType.CHANNEL) continue
+
+			if (!sisyfosMapping.setLabelToLayerName) continue
 
 			if (!sisyfosMapping.layerName) continue
 

--- a/src/types/src/mapping.ts
+++ b/src/types/src/mapping.ts
@@ -7,6 +7,7 @@ export interface Mappings {
 export interface Mapping {
 	device: DeviceType
 	deviceId: string
+	layerName?: string
 }
 
 export interface ResolvedTimelineObjectInstanceExtended extends ResolvedTimelineObjectInstance, TSRTimelineObjProps {

--- a/src/types/src/mapping.ts
+++ b/src/types/src/mapping.ts
@@ -7,6 +7,7 @@ export interface Mappings {
 export interface Mapping {
 	device: DeviceType
 	deviceId: string
+	/** Human-readable name given to the layer. Can be used by devices to set the label of e.g. a fader a mapping points to. */
 	layerName?: string
 }
 

--- a/src/types/src/sisyfos.ts
+++ b/src/types/src/sisyfos.ts
@@ -18,6 +18,7 @@ interface MappingSisyfosBase extends Mapping {
 export interface MappingSisyfosChannel extends MappingSisyfosBase {
 	mappingType: MappingSisyfosType.CHANNEL
 	channel: number
+	setLabelToLayerName: boolean
 }
 export interface MappingSisyfosChannels extends MappingSisyfosBase {
 	mappingType: MappingSisyfosType.CHANNELS


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds the `layerName` property to layer mappings, and utilises this in the Sisyfos integration as the default channel label.


* **What is the current behavior?** (You can also link to an open issue here)

No feature.


* **What is the new behavior (if this is a feature change)?**

This PR adds an optional property to all mappings called `layerName`, which aims to serve two purposes.

First, this allows layer mappings to have a "friendly name" in core, something easier to recognise than the layer id used by blueprints.

Secondly, this PR adds a feature to the Sisyfos integration where, if the `layerName` is not blank, it will be used as the default label for a fader. This means that fader labels do not need to be defined by timeline objects in a studio / rundown baseline, however the default label can be overriden using timeline objects in the same way as the current behaviour. This also has the advantage that a system administrator can change the label of a sisyfos fader through the mapping settings, rather than via blueprints - reducing the need to touch code / reload NRCS data. This could also mean that a route set being activated could change the fader label without needing to rerun blueprints.

This approach could also be applied in the future to set the labels of ATEM sources, display some debug text on a caspar layer, or control the name of a camera in a tally system.


* **Other information**:
