### PR TITLE
fix: don't run out transition when changing clip in preview

### DIFF
--- a/src/devices/__tests__/quantel.spec.ts
+++ b/src/devices/__tests__/quantel.spec.ts
@@ -775,6 +775,149 @@ describe('Quantel', () => {
 		expect(errorHandler).toHaveBeenCalledTimes(0)
 		expect(deviceErrorHandler).toHaveBeenCalledTimes(0)
 	})
+	test('outTransition not tun for lookaheads', async () => {
+		const {
+			commandReceiver0,
+			myConductor,
+			errorHandler,
+			deviceErrorHandler,
+			device
+		} = await setupDefaultQuantelDeviceForTest()
+
+		// Check that no commands has been scheduled:
+		expect(await device.queue).toHaveLength(0)
+
+		myConductor.setTimelineAndMappings([
+			{
+				id: 'video0',
+				enable: {
+					start: 11000,
+					duration: 2000
+				},
+				layer: 'myLayer0',
+				content: {
+					deviceType: DeviceType.QUANTEL,
+
+					title: 'myClip0',
+					notOnAir: true,
+					outTransition: {
+						type: QuantelTransitionType.DELAY,
+						delay: 1000 // ms
+					}
+				}
+			},
+			{
+				id: 'video1',
+				enable: {
+					start: '#video0.end', // 13000
+					duration: 2000
+				},
+				layer: 'myLayer0',
+				content: {
+					deviceType: DeviceType.QUANTEL,
+					title: 'Test0',
+					notOnAir: true,
+					// pauseTime: 13000,
+					noStarttime: true,
+					playing: false
+				}
+			}
+		])
+		// Time to preload the clip
+		await mockTime.advanceTimeToTicks(10990)
+
+		expect(commandReceiver0).toHaveBeenCalledTimes(1)
+		expect(commandReceiver0).toHaveBeenNthCalledWith(1, 10155, expect.objectContaining({
+			type: QuantelCommandType.LOADCLIPFRAGMENTS
+		}), expect.any(String), expect.any(String))
+
+		expect(onRequest).toHaveBeenCalledTimes(6)
+
+		// Search for and get clip info:
+		expect(onRequest).toHaveBeenNthCalledWith(1, 'get', expect.stringContaining('/default/clip?Title=%22myClip0%22'))
+		expect(onRequest).toHaveBeenNthCalledWith(2, 'get', expect.stringContaining('/default/clip/1337'))
+		// Fetch fragments:
+		expect(onRequest).toHaveBeenNthCalledWith(3, 'get', expect.stringContaining('clip/1337/fragments'))
+		// get port info
+		expect(onRequest).toHaveBeenNthCalledWith(4, 'get', expect.stringContaining('default/server/1100/port/my_port'))
+		// Load fragments
+		expect(onRequest).toHaveBeenNthCalledWith(5, 'post',expect.stringContaining('port/my_port/fragments'))
+		// Prepare jump:
+		expect(onRequest).toHaveBeenNthCalledWith(6, 'put',expect.stringContaining('port/my_port/jump?offset=0'))
+
+		clearMocks()
+		commandReceiver0.mockClear()
+
+		// Time to start playing
+		await mockTime.advanceTimeToTicks(11300)
+
+		expect(commandReceiver0).toHaveBeenCalledTimes(1)
+		expect(commandReceiver0).toHaveBeenNthCalledWith(1, 11000, expect.objectContaining({
+			type: QuantelCommandType.PLAYCLIP
+		}), expect.any(String), expect.any(String))
+
+		expect(onRequest).toHaveBeenCalledTimes(3)
+
+		// Trigger Jump
+		// expect(onRequest).toHaveBeenNthCalledWith(1, 'post', expect.stringContaining('/default/server/1100/port/my_port/trigger/JUMP'))
+		// Trigger play
+		expect(onRequest).toHaveBeenNthCalledWith(1, 'post', expect.stringContaining('/default/server/1100/port/my_port/trigger/START'))
+		// Check that play worked
+		expect(onRequest).toHaveBeenNthCalledWith(2, 'get', expect.stringContaining('default/server/1100/port/my_port'))
+		// Plan to stop at end of clip
+		expect(onRequest).toHaveBeenNthCalledWith(3, 'post', expect.stringContaining('/default/server/1100/port/my_port/trigger/STOP?offset=1999'))
+
+		clearMocks()
+		commandReceiver0.mockClear()
+
+		// Time to stop playing
+
+		await mockTime.advanceTimeToTicks(13050)
+
+		expect(commandReceiver0).toHaveBeenCalledTimes(2)
+		expect(commandReceiver0).toHaveBeenNthCalledWith(1, 12000, expect.objectContaining({
+			type: QuantelCommandType.LOADCLIPFRAGMENTS
+		}), expect.any(String), expect.any(String))
+		expect(commandReceiver0).toHaveBeenNthCalledWith(2, 13000, expect.objectContaining({
+			type: QuantelCommandType.PAUSECLIP,
+			transition: undefined
+		}), expect.any(String), expect.any(String))
+
+		expect(onRequest).toHaveBeenCalledTimes(8) // because of no outTransition of #video0
+
+		// Search for and get clip info:
+		expect(onRequest).toHaveBeenNthCalledWith(1, 'get', expect.stringContaining('/default/clip?Title=%22Test0%22'))
+		expect(onRequest).toHaveBeenNthCalledWith(2, 'get', expect.stringContaining('/default/clip/2'))
+		// Fetch fragments:
+		expect(onRequest).toHaveBeenNthCalledWith(3, 'get', expect.stringContaining('clip/2/fragments'))
+		// get port info
+		expect(onRequest).toHaveBeenNthCalledWith(4, 'get', expect.stringContaining('default/server/1100/port/my_port'))
+		// Load fragments
+		expect(onRequest).toHaveBeenNthCalledWith(5, 'post',expect.stringContaining('port/my_port/fragments'))
+		// Prepare jump:
+		expect(onRequest).toHaveBeenNthCalledWith(6, 'put',expect.stringContaining('port/my_port/jump?offset=2000'))
+		// Trigger STOP
+		expect(onRequest).toHaveBeenNthCalledWith(7, 'post', expect.stringContaining('/default/server/1100/port/my_port/trigger/STOP'))
+		// Trigger JUMP
+		expect(onRequest).toHaveBeenNthCalledWith(8, 'post', expect.stringContaining('/default/server/1100/port/my_port/trigger/JUMP'))
+
+		clearMocks()
+		commandReceiver0.mockClear()
+
+		await mockTime.advanceTimeToTicks(16050)
+		expect(commandReceiver0).toHaveBeenCalledTimes(1)
+		expect(commandReceiver0).toHaveBeenNthCalledWith(1, expect.toBeCloseTo(15000, 5), expect.objectContaining({
+			type: QuantelCommandType.CLEARCLIP
+		}), expect.any(String), expect.any(String))
+		expect(onRequest).toHaveBeenCalledTimes(1)
+		// Clear port from clip (reset port)
+		expect(onRequest).toHaveBeenNthCalledWith(1, 'post', expect.stringContaining('/default/server/1100/port/my_port/reset'))
+
+		await myConductor.destroy()
+
+		expect(errorHandler).toHaveBeenCalledTimes(0)
+		expect(deviceErrorHandler).toHaveBeenCalledTimes(0)
+	})
 	test('Play, then pause', async () => {
 		const {
 			commandReceiver0,

--- a/src/devices/quantel.ts
+++ b/src/devices/quantel.ts
@@ -464,8 +464,8 @@ export class QuantelDevice extends DeviceWithState<QuantelState> implements IDev
 					let transition: QuantelOutTransition | undefined
 
 					if (oldPort && !oldPort.notOnAir && newPort.notOnAir) {
-						// The thing that's going to be played is not intended to be on air
-						// We can let the outTransition of the oldCLip run then!
+						// When the previous content was on-air, we use the out-transition (so that mix-effects look good).
+						// But when the previous content wasn't on-air, we don't wan't to use the out-transition (for example; when cuing previews)
 						transition = oldPort.outTransition
 					}
 

--- a/src/devices/quantel.ts
+++ b/src/devices/quantel.ts
@@ -463,7 +463,7 @@ export class QuantelDevice extends DeviceWithState<QuantelState> implements IDev
 
 					let transition: QuantelOutTransition | undefined
 
-					if (oldPort && newPort.notOnAir) {
+					if (oldPort && !oldPort.notOnAir && newPort.notOnAir) {
 						// The thing that's going to be played is not intended to be on air
 						// We can let the outTransition of the oldCLip run then!
 						transition = oldPort.outTransition


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Big fix.

* **What is the current behavior?** (You can also link to an open issue here)

When a lookahead chantges on an off-air port, such as when cueing a BTS, the outTransition runs from one to the other.

* **What is the new behavior (if this is a feature change)?**

Out transitions do not run between clips when the state is "notOnAir true" to "notOnAir" true.

* **Other information**:

Cueing BTSs appears to be delayed by 2 seconds (actually 1400ms plus load clip time) without this change.
