### PR TITLE
fix: multiple VizMSE device fixes

### DIFF
--- a/packages/timeline-state-resolver-types/src/vizMSE.ts
+++ b/packages/timeline-state-resolver-types/src/vizMSE.ts
@@ -11,6 +11,8 @@ export interface VizMSEOptions {
 	restPort?: number
 	/** Port number to the web-sockets interface (optional) */
 	wsPort?: number
+	/** Port number to the REST interfaces of Viz Engines (optional) */
+	engineRestPort?: number
 
 	/** Identifier of the "show" to use */
 	showID: string

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -338,6 +338,7 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 	 * @param okToDestroyStuff Whether it is OK to do things that affects playout visibly
 	 */
 	async makeReady (okToDestroyStuff?: boolean, activeRundownPlaylistId?: string): Promise<void> {
+		const previousPlaylistId = this._vizmseManager?.activeRundownPlaylistId
 		if (this._vizmseManager) {
 			const preload = !!(this._initOptions && this._initOptions.onlyPreloadActivePlaylist)
 			await this._vizmseManager.activate(activeRundownPlaylistId, preload)
@@ -350,7 +351,8 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 			if (this._vizmseManager) {
 				if (
 					this._initOptions &&
-					this._initOptions.clearAllOnMakeReady
+					this._initOptions.clearAllOnMakeReady &&
+					activeRundownPlaylistId !== previousPlaylistId
 				) {
 					if (this._initOptions.clearAllTemplateName) {
 						await this._vizmseManager.clearAll({
@@ -791,6 +793,10 @@ class VizMSEManager extends EventEmitter {
 	private _terminated: boolean = false
 	private _activeRundownPlaylistId: string | undefined
 	private _preloadedRundownPlaylistId: string | undefined
+
+	public get activeRundownPlaylistId () {
+		return this._activeRundownPlaylistId
+	}
 
 	constructor (
 		private _parentVizMSEDevice: VizMSEDevice,

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -337,15 +337,10 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 	 * Prepares the physical device for playout.
 	 * @param okToDestroyStuff Whether it is OK to do things that affects playout visibly
 	 */
-	async makeReady (okToDestroyStuff?: boolean, activeRundownId?: string): Promise<void> {
+	async makeReady (okToDestroyStuff?: boolean, activeRundownPlaylistId?: string): Promise<void> {
 		if (this._vizmseManager) {
-			this._vizmseManager.activePlaylistId = (
-				(this._initOptions && this._initOptions.onlyPreloadActivePlaylist) ?
-				activeRundownId :
-				undefined
-			)
-			await this._vizmseManager.activate()
-
+			const preload = !!(this._initOptions && this._initOptions.onlyPreloadActivePlaylist)
+			await this._vizmseManager.activate(activeRundownPlaylistId, preload)
 		} else throw new Error(`Unable to activate vizMSE, not initialized yet!`)
 
 		if (okToDestroyStuff) {
@@ -773,8 +768,6 @@ class VizMSEManager extends EventEmitter {
 	public initialized: boolean = false
 	public notLoadedCount: number = 0
 	public loadingCount: number = 0
-	/** Currently active playlist in Sofie Core */
-	public activePlaylistId: string | undefined
 	public enginesDisconnected: Array<string> = []
 
 	private _rundown: VRundown | undefined
@@ -795,6 +788,8 @@ class VizMSEManager extends EventEmitter {
 	public ignoreAllWaits: boolean = false // Only to be used in tests
 	private _cacheInternalElementsSentLoaded: {[hash: string]: true} = {}
 	private _terminated: boolean = false
+	private _activeRundownPlaylistId: string | undefined
+	private _preloadedRundownPlaylistId: string | undefined
 
 	constructor (
 		private _parentVizMSEDevice: VizMSEDevice,
@@ -909,21 +904,26 @@ class VizMSEManager extends EventEmitter {
 	 * This causes the MSE rundown to activate, which must be done before using it.
 	 * Doing this will make MSE start loading things onto the vizEngine etc.
 	 */
-	public async activate (): Promise<void> {
-		this._triggerCommandSent()
-		const rundown = await this._getRundown()
+	public async activate (rundownPlaylistId: string | undefined, preload: boolean): Promise<void> {
+		this._preloadedRundownPlaylistId = preload ? rundownPlaylistId : undefined
+		let loadTwice = false
+		if (!rundownPlaylistId || this._activeRundownPlaylistId !== rundownPlaylistId) {
+			this._triggerCommandSent()
+			const rundown = await this._getRundown()
 
-		// clear any existing elements from the existing rundown
-		try {
-			await rundown.purge()
-		} catch (error) {
-			this.emit('error', error)
+			// clear any existing elements from the existing rundown
+			try {
+				await rundown.purge()
+			} catch (error) {
+				this.emit('error', error)
+			}
+			this._clearCache()
+			this._clearMediaObjects()
+			loadTwice = true
 		}
-		this._clearCache()
-		this._clearMediaObjects()
 
 		this._triggerCommandSent()
-		this._triggerLoadAllElements(true).then(() => {
+		this._triggerLoadAllElements(loadTwice).then(() => {
 			this._triggerCommandSent()
 			this._hasActiveRundown = true
 		}).catch((e) => {
@@ -944,6 +944,7 @@ class VizMSEManager extends EventEmitter {
 	}
 	public standDownActiveRundown (): void {
 		this._hasActiveRundown = false
+		this._activeRundownPlaylistId = undefined
 	}
 	private _clearMediaObjects (): void {
 		this.emit('clearMediaObjects', this._parentVizMSEDevice.deviceId)
@@ -1294,8 +1295,8 @@ class VizMSEManager extends EventEmitter {
 			const templateName = typeof expectedPlayoutItem.templateName as string | number | undefined
 			return (
 				(
-					!this.activePlaylistId ||
-					this.activePlaylistId === expectedPlayoutItem.playlistId
+					!this._preloadedRundownPlaylistId ||
+					this._preloadedRundownPlaylistId === expectedPlayoutItem.playlistId
 				) &&
 				typeof templateName !== 'undefined'
 			)
@@ -1360,7 +1361,7 @@ class VizMSEManager extends EventEmitter {
 		}))
 		if (this._rundown) {
 
-			this.emit('debug', `Updating status of elements starting, activePlaylistId="${this.activePlaylistId}", elementsToLoad.length=${elementsToLoad.length} (${_.keys(hashesAndItems).length})`)
+			this.emit('debug', `Updating status of elements starting, activeRundownId="${this._preloadedRundownPlaylistId}", elementsToLoad.length=${elementsToLoad.length} (${_.keys(hashesAndItems).length})`)
 
 			const rundown = await this._getRundown()
 

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -778,8 +778,8 @@ class VizMSEManager extends EventEmitter {
 	private _rundown: VRundown | undefined
 	private _elementCache: {[hash: string]: CachedVElement } = {}
 	private _expectedPlayoutItems: Array<ExpectedPlayoutItem> = []
-	private _monitorAndLoadElementsInterval?: NodeJS.Timer
-	private _monitorMSEConnection?: NodeJS.Timer
+	private _monitorAndLoadElementsTimeout?: NodeJS.Timer
+	private _monitorMSEConnectionTimeout?: NodeJS.Timer
 	private _lastTimeCommandSent: number = 0
 	private _hasActiveRundown: boolean = false
 	private _elementsLoaded: {[hash: string]: { element: VElement, isLoaded: boolean, isLoading: boolean, wasLoaded?: boolean }} = {}
@@ -840,16 +840,7 @@ class VizMSEManager extends EventEmitter {
 
 			// const profile = await this._vizMSE.getProfile('sofie') // TODO: Figure out if this is needed
 
-			if (this._monitorAndLoadElementsInterval) {
-				clearInterval(this._monitorAndLoadElementsInterval)
-			}
-			this._monitorAndLoadElementsInterval = setInterval(() => {
-				this._monitorLoadedElements()
-				.catch((...args) => {
-					this.emit('error', ...args)
-				})
-			}, MONITOR_INTERVAL)
-
+			this._setMonitorLoadedElementsTimeout()
 			this._setMonitorConnectionTimeout()
 
 			this.initialized = true
@@ -862,11 +853,11 @@ class VizMSEManager extends EventEmitter {
 	 */
 	public async terminate () {
 		this._terminated = true
-		if (this._monitorAndLoadElementsInterval) {
-			clearInterval(this._monitorAndLoadElementsInterval)
+		if (this._monitorAndLoadElementsTimeout) {
+			clearTimeout(this._monitorAndLoadElementsTimeout)
 		}
-		if (this._monitorMSEConnection) {
-			clearTimeout(this._monitorMSEConnection)
+		if (this._monitorMSEConnectionTimeout) {
+			clearTimeout(this._monitorMSEConnectionTimeout)
 		}
 		if (this._vizMSE) {
 			await this._vizMSE.close()
@@ -1511,36 +1502,57 @@ class VizMSEManager extends EventEmitter {
 			this._loadingAllElements = false
 		}
 	}
-	private _setMonitorConnectionTimeout (): void {
-		if (this._monitorMSEConnection) {
-			clearTimeout(this._monitorMSEConnection)
+	private _setMonitorLoadedElementsTimeout (): void {
+		if (this._monitorAndLoadElementsTimeout) {
+			clearTimeout(this._monitorAndLoadElementsTimeout)
 		}
 		if (!this._terminated) {
-			this._monitorMSEConnection = setTimeout(() => this._monitorConnection(), MONITOR_INTERVAL)
+			this._monitorAndLoadElementsTimeout = setTimeout(async () => {
+				await this._monitorLoadedElements()
+				.catch((...args) => {
+					this.emit('error', ...args)
+				})
+				this._setMonitorLoadedElementsTimeout()
+			}, MONITOR_INTERVAL)
 		}
 	}
-	private _monitorConnection (): void {
-		// (the ping will throuw on a timeout if ping doesn't return in time)
+	private _setMonitorConnectionTimeout (): void {
+		if (this._monitorMSEConnectionTimeout) {
+			clearTimeout(this._monitorMSEConnectionTimeout)
+		}
+		if (!this._terminated) {
+			this._monitorMSEConnectionTimeout = setTimeout(async () => {
+				await this._monitorConnection()
+				.catch((...args) => {
+					this.emit('error', ...args)
+				})
+				this._setMonitorConnectionTimeout()
+			}, MONITOR_INTERVAL)
+		}
+	}
+	private _monitorConnection (): Promise<void> {
 		if (this.initialized) {
-			this._vizMSE.ping()
-			.then(async () => {
+			// (the ping will throw on a timeout if ping doesn't return in time)
+			return this._vizMSE.ping()
+			.then(() => {
 				// ok!
 				if (!this._msePingConnected) {
 					this._msePingConnected = true
 					this.onConnectionChanged()
 				}
-				await this._monitorEngines()
-				this._setMonitorConnectionTimeout()
-			}, async () => {
+			})
+			.catch(() => {
 				// not ok!
 				if (this._msePingConnected) {
 					this._msePingConnected = false
 					this.onConnectionChanged()
 				}
-				await this._monitorEngines()
-				this._setMonitorConnectionTimeout()
+			})
+			.then(() => {
+				return this._msePingConnected ? this._monitorEngines() : Promise.resolve()
 			})
 		}
+		return Promise.reject()
 	}
 	private async _monitorEngines () {
 		if (!this.engineRestPort) {

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -1531,7 +1531,7 @@ class VizMSEManager extends EventEmitter {
 		const enginesDisconnected: string[] = []
 		statuses.forEach((status) => {
 			if (!status.alive) {
-				enginesDisconnected.push(`${status.name} (${status.host})`)
+				enginesDisconnected.push(`${status.channel || status.name} (${status.host})`)
 			}
 		})
 		if (!_.isEqual(enginesDisconnected, this.enginesDisconnected)) {

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -966,7 +966,7 @@ class VizMSEManager extends EventEmitter {
 	public async prepareElement (cmd: VizMSECommandPrepare): Promise<void> {
 
 		const elementHash = this.getElementHash(cmd)
-		this.emit('debug', `VizMSE: prepare "${elementHash}"`)
+		this.emit('debug', `VizMSE: prepare "${elementHash}" on channel "${cmd.channelName}"`)
 		this._triggerCommandSent()
 		await this._checkPrepareElement(cmd, true)
 		this._triggerCommandSent()
@@ -981,7 +981,7 @@ class VizMSEManager extends EventEmitter {
 
 		await this._checkElementExists(cmd)
 		await this._handleRetry(() => {
-			this.emit('debug', `VizMSE: cue "${elementRef}"`)
+			this.emit('debug', `VizMSE: cue "${elementRef}" on channel "${cmd.channelName}"`)
 			return rundown.cue(elementRef)
 		})
 	}
@@ -1004,7 +1004,7 @@ class VizMSEManager extends EventEmitter {
 
 		await this._checkElementExists(cmd)
 		await this._handleRetry(() => {
-			this.emit('debug', `VizMSE: take "${elementRef}"`)
+			this.emit('debug', `VizMSE: take "${elementRef}" on channel "${cmd.channelName}"`)
 
 			return rundown.take(elementRef)
 		})
@@ -1028,7 +1028,7 @@ class VizMSEManager extends EventEmitter {
 
 		await this._checkElementExists(cmd)
 		await this._handleRetry(() => {
-			this.emit('debug', `VizMSE: out "${elementRef}"`)
+			this.emit('debug', `VizMSE: out "${elementRef}" on channel "${cmd.channelName}"`)
 			return rundown.out(elementRef)
 		})
 	}
@@ -1042,7 +1042,7 @@ class VizMSEManager extends EventEmitter {
 
 		await this._checkElementExists(cmd)
 		await this._handleRetry(() => {
-			this.emit('debug', `VizMSE: continue "${elementRef}"`)
+			this.emit('debug', `VizMSE: continue "${elementRef}" on channel "${cmd.channelName}"`)
 			return rundown.continue(elementRef)
 		})
 	}
@@ -1056,7 +1056,7 @@ class VizMSEManager extends EventEmitter {
 
 		await this._checkElementExists(cmd)
 		await this._handleRetry(() => {
-			this.emit('debug', `VizMSE: continue reverse "${elementRef}"`)
+			this.emit('debug', `VizMSE: continue reverse "${elementRef}" on channel "${cmd.channelName}"`)
 			return rundown.continueReverse(elementRef)
 		})
 	}

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -1408,7 +1408,7 @@ class VizMSEManager extends EventEmitter {
 									_rev: ''
 								}
 								this.emit('updateMediaObject', e.hash, mediaObject)
-							} else if (!cachedEl) {
+							} else {
 								this.emit('updateMediaObject', e.hash, null)
 							}
 						}

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -1337,7 +1337,7 @@ class VizMSEManager extends EventEmitter {
 						hashesAndItems[this.getElementHash(item)] = item
 					}
 				} catch (e) {
-					this.emit('error', `Error in _getExpectedPlayoutItems: ${e.toString()}`)
+					this.emit('error', `Error in _getExpectedPlayoutItems for "${expectedPlayoutItem.templateName}": ${e.toString()}`)
 				}
 			})
 		)

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -916,7 +916,7 @@ class VizMSEManager extends EventEmitter {
 			// clear any existing elements from the existing rundown
 			try {
 				this.emit('debug', `VizMSE: purging rundown`)
-				const elementsToKeep = (this._expectedPlayoutItems.filter((item) => !item.playlistId && _.isNumber(item.templateName)) as { templateName: number, channelName?: string }[]).map((item => ({ vcpid: item.templateName, channelName: item.channelName })))
+				const elementsToKeep = (this._expectedPlayoutItems.filter((item) => item.baseline && _.isNumber(item.templateName)) as { templateName: number, channelName?: string }[]).map((item => ({ vcpid: item.templateName, channelName: item.channelName })))
 				await rundown.purge(elementsToKeep)
 			} catch (error) {
 				this.emit('error', error)

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -1542,7 +1542,7 @@ class VizMSEManager extends EventEmitter {
 	private async _pingEngine (engine: Engine): Promise<EngineStatus> {
 		return new Promise((resolve, _reject) => {
 			request.get(`http://${engine.host}:${this.engineRestPort}/#/status`, { timeout: 2000 }, (error, response) => {
-				const alive = !error && response.statusCode === 200
+				const alive = !error && response.statusCode < 400
 				resolve({ ...engine, alive })
 			})
 		})

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -915,7 +915,9 @@ class VizMSEManager extends EventEmitter {
 
 			// clear any existing elements from the existing rundown
 			try {
-				await rundown.purge()
+				this.emit('debug', `VizMSE: purging rundown`)
+				const elementsToKeep = (this._expectedPlayoutItems.filter((item) => !item.playlistId && _.isNumber(item.templateName)) as { templateName: number, channelName?: string }[]).map((item => ({ vcpid: item.templateName, channelName: item.channelName })))
+				await rundown.purge(elementsToKeep)
 			} catch (error) {
 				this.emit('error', error)
 			}
@@ -1298,6 +1300,7 @@ class VizMSEManager extends EventEmitter {
 			return (
 				(
 					!this._preloadedRundownPlaylistId ||
+					!expectedPlayoutItem.playlistId ||
 					this._preloadedRundownPlaylistId === expectedPlayoutItem.playlistId
 				) &&
 				typeof templateName !== 'undefined'

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -36,9 +36,7 @@ import {
 	VRundown,
 	InternalElement,
 	ExternalElement,
-	VElement,
-	VProfile,
-	VizEngine
+	VElement
 } from 'v-connection'
 
 import { DoOnTime, SendMode } from '../doOnTime'
@@ -46,6 +44,7 @@ import { DoOnTime, SendMode } from '../doOnTime'
 import * as crypto from 'crypto'
 import * as net from 'net'
 import { ExpectedPlayoutItem } from '../expectedPlayoutItems'
+import * as request from 'request'
 
 /** The ideal time to prepare elements before going on air */
 const IDEAL_PREPARE_TIME = 1000
@@ -73,6 +72,8 @@ export interface DeviceOptionsVizMSEInternal extends DeviceOptionsVizMSE {
 	)
 }
 export type CommandReceiver = (time: number, cmd: VizMSECommand, context: string, timelineObjId: string) => Promise<any>
+export type Engine = {name: string, channel?: string, host: string, port: number}
+type EngineStatus = Engine & { alive: boolean }
 /**
  * This class is used to interface with a vizRT Media Sequence Editor, through the v-connection library.
  * It features playing both "internal" graphics element and vizPilot elements.
@@ -125,6 +126,7 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 			this._vizMSE,
 			this._initOptions.preloadAllElements,
 			this._initOptions.autoLoadInternalElements,
+			this._initOptions.engineRestPort,
 			initOptions.showID,
 			initOptions.profile,
 			initOptions.playlistID
@@ -402,15 +404,17 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 		if (!this._vizMSEConnected) {
 			statusCode = StatusCode.BAD
 			messages.push('Not connected')
-		} else if (
-			this._vizmseManager &&
-			(
-				this._vizmseManager.notLoadedCount > 0 ||
-				this._vizmseManager.loadingCount > 0
-			)
-		) {
-			statusCode = StatusCode.WARNING_MINOR
-			messages.push(`Got ${this._vizmseManager.notLoadedCount} elements not yet loaded to the Viz Engine (${this._vizmseManager.loadingCount} are currently loading)`)
+		} else if (this._vizmseManager) {
+			if (this._vizmseManager.notLoadedCount > 0 || this._vizmseManager.loadingCount > 0) {
+				statusCode = StatusCode.WARNING_MINOR
+				messages.push(`Got ${this._vizmseManager.notLoadedCount} elements not yet loaded to the Viz Engine (${this._vizmseManager.loadingCount} are currently loading)`)
+			}
+			if (this._vizmseManager.enginesDisconnected.length) {
+				statusCode = StatusCode.BAD
+				this._vizmseManager.enginesDisconnected.forEach(engine => {
+					messages.push(`Viz Engine ${engine} disconnected`)
+				})
+			}
 		}
 
 		return {
@@ -771,6 +775,7 @@ class VizMSEManager extends EventEmitter {
 	public loadingCount: number = 0
 	/** Currently active playlist in Sofie Core */
 	public activePlaylistId: string | undefined
+	public enginesDisconnected: Array<string> = []
 
 	private _rundown: VRundown | undefined
 	private _elementCache: {[hash: string]: CachedVElement } = {}
@@ -788,12 +793,14 @@ class VizMSEManager extends EventEmitter {
 	} = {}
 	public ignoreAllWaits: boolean = false // Only to be used in tests
 	private _cacheInternalElementsSentLoaded: {[hash: string]: true} = {}
+	private _terminated: boolean = false
 
 	constructor (
 		private _parentVizMSEDevice: VizMSEDevice,
 		private _vizMSE: MSE,
 		public preloadAllElements: boolean = false,
 		public autoLoadInternalElements: boolean = false,
+		public engineRestPort: number | undefined,
 		private _showID: string,
 		private _profile: string,
 		private _playlistID?: string
@@ -836,10 +843,7 @@ class VizMSEManager extends EventEmitter {
 				})
 			}, MONITOR_INTERVAL)
 
-			if (this._monitorMSEConnection) {
-				clearInterval(this._monitorMSEConnection)
-			}
-			this._monitorMSEConnection = setInterval(() => this._monitorConnection(), MONITOR_INTERVAL)
+			this._setMonitorConnectionTimeout()
 
 			this.initialized = true
 		}
@@ -850,11 +854,12 @@ class VizMSEManager extends EventEmitter {
 	 * Close connections and die
 	 */
 	public async terminate () {
+		this._terminated = true
 		if (this._monitorAndLoadElementsInterval) {
 			clearInterval(this._monitorAndLoadElementsInterval)
 		}
 		if (this._monitorMSEConnection) {
-			clearInterval(this._monitorMSEConnection)
+			clearTimeout(this._monitorMSEConnection)
 		}
 		if (this._vizMSE) {
 			await this._vizMSE.close()
@@ -1074,9 +1079,8 @@ class VizMSEManager extends EventEmitter {
 	 */
 	public async clearEngines (cmd: VizMSECommandClearAllEngines): Promise<void> {
 		try {
-			const profile = await this._vizMSE.getProfile(this._profile)
-			const engines = await this._vizMSE.getEngines()
-			const enginesToClear = this._prepareEnginesToClear(profile, engines, cmd.channels)
+			const engines = await this._getEngines()
+			const enginesToClear = this._filterEnginesToClear(engines, cmd.channels)
 			enginesToClear.forEach(engine => {
 				const sender = new VizEngineTcpSender(engine.port, engine.host)
 				sender.on('warning', w => this.emit('warning', `clearEngines: ${w}`))
@@ -1087,8 +1091,10 @@ class VizMSEManager extends EventEmitter {
 			this.emit('warning', `Sending Clear-all command failed ${e}`)
 		}
 	}
-	private _prepareEnginesToClear (profile: VProfile, engines: VizEngine[], channels: string[] | 'all'): Array<{host: string, port: number}> {
-		const enginesToClear: Array<{host: string, port: number}> = []
+	private async _getEngines (): Promise<Engine[]> {
+		const profile = await this._vizMSE.getProfile(this._profile)
+		const engines = await this._vizMSE.getEngines()
+		const result: Engine[] = []
 		const outputs = new Map<string, string>() // engine name : channel name
 		_.each(profile.execution_groups, (group, groupName) => {
 			_.each(group, entry => {
@@ -1105,15 +1111,16 @@ class VizMSEManager extends EventEmitter {
 		outputEngines.forEach(engine => {
 			_.each(_.keys(engine.renderer), fullHost => {
 				const channelName = outputs.get(engine.name)
-				if (channels === 'all' || _.contains(channels, channelName)) {
-					const match = fullHost.match(/([^:]+):?(\d*)?/)
-					const port = (match && match[2]) ? parseInt(match[2], 10) : 6100
-					const host = (match && match[1]) ? match[1] : fullHost
-					enginesToClear.push({ host, port })
-				}
+				const match = fullHost.match(/([^:]+):?(\d*)?/)
+				const port = (match && match[2]) ? parseInt(match[2], 10) : 6100
+				const host = (match && match[1]) ? match[1] : fullHost
+				result.push({ name: engine.name, channel: channelName, host, port })
 			})
 		})
-		return enginesToClear
+		return result
+	}
+	private _filterEnginesToClear (engines: Engine[], channels: string[] | 'all'): Array<{host: string, port: number}> {
+		return engines.filter(engine => channels === 'all' || engine.channel && channels.includes(engine.channel))
 	}
 	/**
 	 * Load all elements: Trigger a loading of all pilot elements onto the vizEngine.
@@ -1467,24 +1474,65 @@ class VizMSEManager extends EventEmitter {
 
 		this.emit('debug', '_triggerLoadAllElements done')
 	}
+	private _setMonitorConnectionTimeout (): void {
+		if (this._monitorMSEConnection) {
+			clearTimeout(this._monitorMSEConnection)
+		}
+		if (!this._terminated) {
+			this._monitorMSEConnection = setTimeout(() => this._monitorConnection(), MONITOR_INTERVAL)
+		}
+	}
 	private _monitorConnection (): void {
 		// (the ping will throuw on a timeout if ping doesn't return in time)
 		if (this.initialized) {
 			this._vizMSE.ping()
-			.then(() => {
+			.then(async () => {
 				// ok!
 				if (!this._msePingConnected) {
 					this._msePingConnected = true
 					this.onConnectionChanged()
 				}
-			}, () => {
+				await this._monitorEngines()
+				this._setMonitorConnectionTimeout()
+			}, async () => {
 				// not ok!
 				if (this._msePingConnected) {
 					this._msePingConnected = false
 					this.onConnectionChanged()
 				}
+				await this._monitorEngines()
+				this._setMonitorConnectionTimeout()
 			})
 		}
+	}
+	private async _monitorEngines () {
+		if (!this.engineRestPort) {
+			return
+		}
+		const engines = await this._getEngines()
+		const ps: Promise<EngineStatus>[] = []
+		engines.forEach(engine => {
+			return ps.push(this._pingEngine(engine))
+		})
+		const statuses = await Promise.all(ps)
+		const enginesDisconnected: string[] = []
+		statuses.forEach((status) => {
+			if (!status.alive) {
+				enginesDisconnected.push(`${status.name} (${status.host})`)
+			}
+		})
+		if (!_.isEqual(enginesDisconnected, this.enginesDisconnected)) {
+			this.enginesDisconnected = enginesDisconnected
+			this.onConnectionChanged()
+		}
+	}
+	private async _pingEngine (engine: Engine): Promise<EngineStatus> {
+		return new Promise((resolve, _reject) => {
+			request.get(`http://${engine.host}:${this.engineRestPort}/#/status`, { timeout: 2000 }, (error, response) => {
+				const alive = !error && response.statusCode === 200
+				resolve({ ...engine, alive })
+			})
+		})
 	}
 	/** Monitor loading status of expected elements */
 	private async _monitorLoadedElements (): Promise<void> {

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -1280,10 +1280,10 @@ class VizMSEManager extends EventEmitter {
 				return internalEl
 			}
 		} catch (e) {
-			if (e.toString().match(/already exist/i)) { // "An internal graphics element with name 'xxxxxxxxxxxxxxx' already exists."
+			if (e.toString().match(/already exist/i)) { // "An internal/external graphics element with name 'xxxxxxxxxxxxxxx' already exists."
 				// If the object already exists, it's not an error, fetch and use the element instead
 
-				const element = await rundown.getElement(cmd.templateInstance)
+				const element = _.isNumber(cmd.templateName) ? await rundown.getElement(cmd.templateName) : await rundown.getElement(cmd.templateInstance)
 
 				this._cacheElement(elementHash, element)
 				return element

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -1293,7 +1293,7 @@ class VizMSEManager extends EventEmitter {
 
 		const hashesAndItems: {[hash: string]: VizMSEPlayoutItemContentInternal} = {}
 
-		const expectedPlayoutItems = _.filter(this._expectedPlayoutItems, expectedPlayoutItem => {
+		const expectedPlayoutItems = _.uniq(_.filter(this._expectedPlayoutItems, expectedPlayoutItem => {
 			const templateName = typeof expectedPlayoutItem.templateName as string | number | undefined
 			return (
 				(
@@ -1302,7 +1302,7 @@ class VizMSEManager extends EventEmitter {
 				) &&
 				typeof templateName !== 'undefined'
 			)
-		})
+		}), false, (a) => JSON.stringify(_.pick(a, 'templateName', 'templateData', 'channelName')))
 
 		await Promise.all(
 			_.map(expectedPlayoutItems, async expectedPlayoutItem => {

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -1394,7 +1394,7 @@ class VizMSEManager extends EventEmitter {
 							element: newEl,
 							isLoaded: this._isElementLoaded(newEl),
 							isLoading: this._isElementLoading(newEl),
-							wasLoaded: cachedEl.wasLoaded
+							wasLoaded: cachedEl?.wasLoaded
 						}
 						this._elementsLoaded[e.hash] = newLoadedEl
 						this.emit('debug', `Element ${elementRef}: ${JSON.stringify(newEl)}`)

--- a/packages/timeline-state-resolver/src/expectedPlayoutItems.ts
+++ b/packages/timeline-state-resolver/src/expectedPlayoutItems.ts
@@ -5,6 +5,8 @@ export interface ExpectedPlayoutItemContentBase {
 	rundownId: string
 	/** Id of the rundown playlist the items comes from */
 	playlistId: string
+	/** Is created for studio/rundown baseline */
+	baseline?: 'rundown' | 'studio'
 }
 
 export type ExpectedPlayoutItem = ExpectedPlayoutItemContent & ExpectedPlayoutItemContentBase


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fixes and minor features in the VizMSE device


* **What is the current behavior?** (You can also link to an open issue here)

  - `makeReady` waits for initializations, halting playlist activation for a couple seconds
  - active<->rehearsal purges elements
  - duplication of some elements occurs

* **What is the new behavior (if this is a feature change)?**
  fixes above, and:

  - prevents from purging baseline expectedPlayoutItems
  - improves logging
  - reports Viz Engines that become unavailable
  - attempts to reload elements after an Engine is restart

* **Other information**:
depends on https://github.com/olzzon/v-connection/pull/14 and https://github.com/olzzon/v-connection/pull/18