### PR TITLE
Add Panasonic PTZ API Focus and Iris Control

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,95 @@
+name: Publish prerelease
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 15
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        lib-name: [timeline-state-resolver, timeline-state-resolver-types]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Prepare Environment
+        run: |
+          yarn install
+        env:
+          CI: true
+      - name: Run tests
+        run: |
+          cd packages/${{ matrix.lib-name }}
+          yarn unit
+        env:
+          CI: true
+
+  prerelease:
+    name: Prerelease
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 15
+
+    needs:
+      - test
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - name: Check release is desired
+        id: do-publish
+        run: |
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "No Token"
+          elif [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            echo "Publish nightly"
+            echo ::set-output name=publish::"nightly"
+          else
+            echo "Publish experimental"
+            echo ::set-output name=publish::"experimental"
+          fi
+      - name: Get the Prerelease tag
+        id: prerelease-tag
+        uses: yuya-takeyama/docker-tag-from-github-ref-action@2b0614b1338c8f19dd9d3ea433ca9bc0cc7057ba
+        with:
+          remove-version-tag-prefix: false
+      - name: Prepare Environment
+        if: ${{ steps.do-publish.outputs.publish }}
+        run: |
+          yarn install
+          yarn build
+        env:
+          CI: true
+      - name: Bump version and build
+        if: ${{ steps.do-publish.outputs.publish }}
+        run: |
+          COMMIT_TIMESTAMP=$(git log -1 --pretty=format:%ct HEAD)
+          COMMIT_DATE=$(date -d @$COMMIT_TIMESTAMP +%Y%m%d-%H%M%S)
+          GIT_HASH=$(git rev-parse --short HEAD)
+          PRERELEASE_TAG=nightly-$(echo "${{ steps.prerelease-tag.outputs.tag }}" | sed -r 's/[^a-z0-9]+/-/gi')
+          yarn release:bump-prerelease --no-changelog --no-git-tag-version --no-push --no-commit-hooks --exact --preid "$PRERELEASE_TAG-$COMMIT_DATE-$GIT_HASH"
+
+        env:
+          CI: true
+      - name: Publish to NPM
+        if: ${{ steps.do-publish.outputs.publish }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          yarn lerna publish from-package --tag-version-prefix='' --dist-tag ${{ steps.do-publish.outputs.publish }} --yes
+        env:
+          CI: true


### PR DESCRIPTION
Add focus and iris control.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature add - adds focus and iris control to Panasonic PTZ API

* **What is the current behavior?** (You can also link to an open issue here)
No current Focus/Iris control, only Zoom.

* **What is the new behavior (if this is a feature change)?**
Adds focus/iris control.

* **Other information**:
Reference: https://eww.pass.panasonic.co.jp/pro-av/support/content/guide/DEF/HE50_120_IP/HDIntegratedCamera_InterfaceSpecifications-E.pdf