### PR TITLE
feat: resend failing http commands

### DIFF
--- a/packages/timeline-state-resolver-types/src/httpSend.ts
+++ b/packages/timeline-state-resolver-types/src/httpSend.ts
@@ -18,7 +18,7 @@ export interface HTTPSendOptions {
 	/** Whether a makeReady should be treated as a reset of the device. It should be assumed clean, with the queue discarded, and state reapplied from empty */
 	makeReadyDoesReset?: boolean
 
-	/** */
+	/** Minimum time in ms before a command is resent, set to <= 0 or undefined to disable */
 	resendTime?: number
 }
 

--- a/packages/timeline-state-resolver-types/src/httpSend.ts
+++ b/packages/timeline-state-resolver-types/src/httpSend.ts
@@ -17,6 +17,9 @@ export interface HTTPSendOptions {
 	makeReadyCommands?: HTTPSendCommandContent[]
 	/** Whether a makeReady should be treated as a reset of the device. It should be assumed clean, with the queue discarded, and state reapplied from empty */
 	makeReadyDoesReset?: boolean
+
+	/** */
+	resendTime?: number
 }
 
 export enum TimelineContentTypeHTTP {

--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -1,144 +1,145 @@
 {
-  "name": "timeline-state-resolver",
-  "version": "6.0.1-release36",
-  "description": "Have timeline, control stuff",
-  "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
-  "module": "dist/module/index.js",
-  "browser": "dist/browser/index.js",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nrkno/tv-automation-state-timeline-resolver.git"
-  },
-  "bugs": {
-    "url": "https://github.com/nrkno/tv-automation-state-timeline-resolver/issues"
-  },
-  "homepage": "https://github.com/nrkno/tv-automation-state-timeline-resolver#readme",
-  "contributors": [
-    {
-      "name": "Johan Nyman",
-      "email": "johan@superfly.tv",
-      "url": "http://superfly.tv"
-    },
-    {
-      "name": "Balte de Wit",
-      "email": "balte@superfly.tv",
-      "url": "http://superfly.tv"
-    },
-    {
-      "name": "Jesper Stærkær",
-      "email": "jesper@superfly.tv",
-      "url": "http://superfly.tv"
-    },
-    {
-      "name": "Jan Starzak",
-      "email": "jan@superfly.tv",
-      "url": "http://superfly.tv"
-    },
-    {
-      "name": "Stephan Nordnes Eriksen",
-      "email": "Stephanruler@gmail.com"
-    },
-    {
-      "name": "Julian Waller",
-      "email": "julian@superfly.tv",
-      "url": "http://superfly.tv"
-    }
-  ],
-  "scripts": {
-    "info": "npm-scripts-info",
-    "unlink:all": "yarn unlink atem-connection & yarn unlink atem-state & yarn unlink casparcg-connection & yarn unlink casparcg-state & yarn unlink superfly-timeline",
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.build.json",
-    "unit": "jest --forceExit",
-    "test": "yarn lint && yarn unit",
-    "test:integration": "yarn lint && jest --config=jest-integration.config.js",
-    "watch": "jest --watch",
-    "cov": "jest --coverage && yarn cov-open",
-    "cov-open": "open-cli coverage/lcov-report/index.html",
-    "send-coverage": "codecov -p ../..",
-    "validate:dependencies": "yarn audit --groups dependencies && yarn license-validate",
-    "validate:dev-dependencies": "yarn audit --groups devDependencies",
-    "license-validate": "node-license-validator -p -d --allow-licenses MIT BSD BSD-2-Clause BSD-3-Clause 0BSD ISC Apache Unlicense WTFPL --allow-packages cycle",
-    "validate:dev-dependencies": "yarn audit --groups devDependencies",
-    "lint": "eslint . --ext .ts --ext .js --ext .tsx --ext .jsx --ignore-pattern dist",
-    "lint-fix": "yarn lint --fix",
-    "license-validate": "yarn sofie-licensecheck",
-    "precommit": "lint-staged"
-  },
-  "scripts-info": {
-    "info": "Display information about the scripts",
-    "build": "(Trash and re)build the library",
-    "build:main": "Builds main build command without trash.",
-    "lint": "Lint all typescript source files",
-    "unit": "Build the library and run unit tests",
-    "test": "Lint, build, and test the library",
-    "test:integration": "Integration tests. Work in progress",
-    "watch": "Watch source files, rebuild library on changes, rerun relevant tests",
-    "cov": "Run tests, generate the HTML coverage report, and open it in a browser",
-    "cov-open": "Open current test coverage",
-    "send-coverage": "send coverage to codecov",
-    "validate:dependencies": "Scan dependencies for vulnerabilities and check licenses",
-    "license-validate": "Validate licenses for dependencies."
-  },
-  "engines": {
-    "node": ">=12.18"
-  },
-  "files": [
-    "/dist",
-    "/CHANGELOG.md",
-    "/README.md",
-    "/LICENSE"
-  ],
-  "keywords": [
-    "broadcast",
-    "socket",
-    "typescript",
-    "javascript",
-    "open",
-    "source",
-    "automation",
-    "rundown",
-    "production"
-  ],
-  "dependencies": {
-    "atem-connection": "2.3.0-nightly-v2-x-20210608-120229-97c45a9.0",
-    "atem-state": "0.12.0-nightly-latest-20210608-103549-6217657.0",
-    "casparcg-connection": "^5.1.0",
-    "casparcg-state": "^2.1.0",
-    "debug": "^4.3.1",
-    "deepmerge": "^4.2.2",
-    "emberplus-connection": "^0.0.3",
-    "eventemitter3": "^4.0.7",
-    "hyperdeck-connection": "^0.4.3",
-    "osc": "^2.4.0",
-    "p-all": "^3.0.0",
-    "p-queue": "^6.4.0",
-    "p-timeout": "^3.2.0",
-    "request": "^2.88.0",
-    "sprintf-js": "^1.1.2",
-    "superfly-timeline": "^8.2.1",
-    "threadedclass": "0.8.3",
-    "timeline-state-resolver-types": "6.0.1-release36",
-    "tslib": "^2.1.0",
-    "tv-automation-quantel-gateway-client": "^1.0.12",
-    "underscore": "^1.12.0",
-    "underscore-deep-extend": "^1.1.5",
-    "utf-8-validate": "^5.0.2",
-    "v-connection": "git+https://github.com/olzzon/v-connection#v20210604_1",
-    "ws": "^7.4.6",
-    "xml-js": "^1.6.11"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "lint-staged": {
-    "*.{css,json,md,scss}": [
-      "prettier --write"
-    ],
-    "*.{ts,tsx,js,jsx}": [
-      "yarn lint-fix"
-    ]
-  }
+	"name": "timeline-state-resolver",
+	"version": "6.0.1-release36",
+	"description": "Have timeline, control stuff",
+	"main": "dist/index.js",
+	"typings": "dist/index.d.ts",
+	"module": "dist/module/index.js",
+	"browser": "dist/browser/index.js",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/nrkno/tv-automation-state-timeline-resolver.git"
+	},
+	"bugs": {
+		"url": "https://github.com/nrkno/tv-automation-state-timeline-resolver/issues"
+	},
+	"homepage": "https://github.com/nrkno/tv-automation-state-timeline-resolver#readme",
+	"contributors": [
+		{
+			"name": "Johan Nyman",
+			"email": "johan@superfly.tv",
+			"url": "http://superfly.tv"
+		},
+		{
+			"name": "Balte de Wit",
+			"email": "balte@superfly.tv",
+			"url": "http://superfly.tv"
+		},
+		{
+			"name": "Jesper Stærkær",
+			"email": "jesper@superfly.tv",
+			"url": "http://superfly.tv"
+		},
+		{
+			"name": "Jan Starzak",
+			"email": "jan@superfly.tv",
+			"url": "http://superfly.tv"
+		},
+		{
+			"name": "Stephan Nordnes Eriksen",
+			"email": "Stephanruler@gmail.com"
+		},
+		{
+			"name": "Julian Waller",
+			"email": "julian@superfly.tv",
+			"url": "http://superfly.tv"
+		}
+	],
+	"scripts": {
+		"info": "npm-scripts-info",
+		"unlink:all": "yarn unlink atem-connection & yarn unlink atem-state & yarn unlink casparcg-connection & yarn unlink casparcg-state & yarn unlink superfly-timeline",
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.build.json",
+		"unit": "jest --forceExit",
+		"test": "yarn lint && yarn unit",
+		"test:integration": "yarn lint && jest --config=jest-integration.config.js",
+		"watch": "jest --watch",
+		"cov": "jest --coverage && yarn cov-open",
+		"cov-open": "open-cli coverage/lcov-report/index.html",
+		"send-coverage": "codecov -p ../..",
+		"validate:dependencies": "yarn audit --groups dependencies && yarn license-validate",
+		"validate:dev-dependencies": "yarn audit --groups devDependencies",
+		"license-validate": "node-license-validator -p -d --allow-licenses MIT BSD BSD-2-Clause BSD-3-Clause 0BSD ISC Apache Unlicense WTFPL --allow-packages cycle",
+		"validate:dev-dependencies": "yarn audit --groups devDependencies",
+		"lint": "eslint . --ext .ts --ext .js --ext .tsx --ext .jsx --ignore-pattern dist",
+		"lint-fix": "yarn lint --fix",
+		"license-validate": "yarn sofie-licensecheck",
+		"precommit": "lint-staged"
+	},
+	"scripts-info": {
+		"info": "Display information about the scripts",
+		"build": "(Trash and re)build the library",
+		"build:main": "Builds main build command without trash.",
+		"lint": "Lint all typescript source files",
+		"unit": "Build the library and run unit tests",
+		"test": "Lint, build, and test the library",
+		"test:integration": "Integration tests. Work in progress",
+		"watch": "Watch source files, rebuild library on changes, rerun relevant tests",
+		"cov": "Run tests, generate the HTML coverage report, and open it in a browser",
+		"cov-open": "Open current test coverage",
+		"send-coverage": "send coverage to codecov",
+		"validate:dependencies": "Scan dependencies for vulnerabilities and check licenses",
+		"license-validate": "Validate licenses for dependencies."
+	},
+	"engines": {
+		"node": ">=12.18"
+	},
+	"files": [
+		"/dist",
+		"/CHANGELOG.md",
+		"/README.md",
+		"/LICENSE"
+	],
+	"keywords": [
+		"broadcast",
+		"socket",
+		"typescript",
+		"javascript",
+		"open",
+		"source",
+		"automation",
+		"rundown",
+		"production"
+	],
+	"dependencies": {
+		"atem-connection": "2.3.0-nightly-v2-x-20210608-120229-97c45a9.0",
+		"atem-state": "0.12.0-nightly-latest-20210608-103549-6217657.0",
+		"casparcg-connection": "^5.1.0",
+		"casparcg-state": "^2.1.0",
+		"debug": "^4.3.1",
+		"deepmerge": "^4.2.2",
+		"emberplus-connection": "^0.0.3",
+		"eventemitter3": "^4.0.7",
+		"got": "^11.8.2",
+		"hyperdeck-connection": "^0.4.3",
+		"osc": "^2.4.0",
+		"p-all": "^3.0.0",
+		"p-queue": "^6.4.0",
+		"p-timeout": "^3.2.0",
+		"request": "^2.88.0",
+		"sprintf-js": "^1.1.2",
+		"superfly-timeline": "^8.2.1",
+		"threadedclass": "0.8.3",
+		"timeline-state-resolver-types": "6.0.1-release36",
+		"tslib": "^2.1.0",
+		"tv-automation-quantel-gateway-client": "^1.0.12",
+		"underscore": "^1.12.0",
+		"underscore-deep-extend": "^1.1.5",
+		"utf-8-validate": "^5.0.2",
+		"v-connection": "git+https://github.com/olzzon/v-connection#v20210604_1",
+		"ws": "^7.4.6",
+		"xml-js": "^1.6.11"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"lint-staged": {
+		"*.{css,json,md,scss}": [
+			"prettier --write"
+		],
+		"*.{ts,tsx,js,jsx}": [
+			"yarn lint-fix"
+		]
+	}
 }

--- a/packages/timeline-state-resolver/src/devices/__tests__/httpsend.spec.ts
+++ b/packages/timeline-state-resolver/src/devices/__tests__/httpsend.spec.ts
@@ -87,7 +87,8 @@ describe('HTTP-Send', () => {
 				},
 			}),
 			expect.anything(),
-			expect.stringContaining('obj0')
+			expect.stringContaining('obj0'),
+			expect.anything()
 		)
 		expect(getMockCall(commandReceiver0, 0, 2)).toMatch(/added/) // context
 		await mockTime.advanceTimeToTicks(16000)
@@ -189,21 +190,24 @@ describe('HTTP-Send', () => {
 			expect.anything(),
 			expect.objectContaining({ url: 'http://superfly.tv/1' }),
 			expect.anything(),
-			expect.stringContaining('obj0')
+			expect.stringContaining('obj0'),
+			expect.anything()
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
 			2,
 			expect.anything(),
 			expect.objectContaining({ url: 'http://superfly.tv/3' }),
 			expect.anything(),
-			expect.stringContaining('obj2')
+			expect.stringContaining('obj2'),
+			expect.anything()
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
 			3,
 			expect.anything(),
 			expect.objectContaining({ url: 'http://superfly.tv/2' }),
 			expect.anything(),
-			expect.stringContaining('obj1')
+			expect.stringContaining('obj1'),
+			expect.anything()
 		)
 	})
 })

--- a/packages/timeline-state-resolver/src/devices/httpSend.ts
+++ b/packages/timeline-state-resolver/src/devices/httpSend.ts
@@ -62,7 +62,7 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 	init(initOptions: HTTPSendOptions): Promise<boolean> {
 		this._makeReadyCommands = initOptions.makeReadyCommands || []
 		this._makeReadyDoesReset = initOptions.makeReadyDoesReset || false
-		this._resendTime = initOptions.resendTime && initOptions.resendTime > 999 ? initOptions.resendTime : undefined
+		this._resendTime = initOptions.resendTime && initOptions.resendTime > 1 ? initOptions.resendTime : undefined
 
 		return Promise.resolve(true) // This device doesn't have any initialization procedure
 	}
@@ -261,7 +261,6 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 			this.emit('commandError', error, cwc)
 
 			if (this._resendTime) {
-				console.log('cmd error', Date.now())
 				const timeLeft = Math.max(this._resendTime - (Date.now() - t), 0)
 				await new Promise<void>((resolve) => setTimeout(() => resolve(), timeLeft))
 				this._defaultCommandReceiver(_time, cmd, context, timelineObjId, layer).catch(() => null) // errors will be emitted

--- a/packages/timeline-state-resolver/src/devices/httpSend.ts
+++ b/packages/timeline-state-resolver/src/devices/httpSend.ts
@@ -8,7 +8,7 @@ import {
 	Mappings,
 } from 'timeline-state-resolver-types'
 import { DoOnTime, SendMode } from '../doOnTime'
-import * as request from 'request'
+import got from 'got'
 
 import { TimelineState, ResolvedTimelineObjectInstance } from 'superfly-timeline'
 export interface DeviceOptionsHTTPSendInternal extends DeviceOptionsHTTPSend {
@@ -18,7 +18,8 @@ export type CommandReceiver = (
 	time: number,
 	cmd: HTTPSendCommandContent,
 	context: CommandContext,
-	timelineObjId: string
+	timelineObjId: string,
+	layer?: string
 ) => Promise<any>
 interface Command {
 	commandName: 'added' | 'changed' | 'removed'
@@ -37,9 +38,11 @@ type HTTPSendState = TimelineState
 export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptionsHTTPSendInternal> {
 	private _makeReadyCommands: HTTPSendCommandContent[]
 	private _makeReadyDoesReset: boolean
+	private _resendTime?: number
 	private _doOnTime: DoOnTime
 
 	private _commandReceiver: CommandReceiver
+	private activeLayers = new Map<string, string>()
 
 	constructor(deviceId: string, deviceOptions: DeviceOptionsHTTPSendInternal, getCurrentTime: () => Promise<number>) {
 		super(deviceId, deviceOptions, getCurrentTime)
@@ -59,6 +62,7 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 	init(initOptions: HTTPSendOptions): Promise<boolean> {
 		this._makeReadyCommands = initOptions.makeReadyCommands || []
 		this._makeReadyDoesReset = initOptions.makeReadyDoesReset || false
+		this._resendTime = initOptions.resendTime && initOptions.resendTime > 999 ? initOptions.resendTime : undefined
 
 		return Promise.resolve(true) // This device doesn't have any initialization procedure
 	}
@@ -151,8 +155,10 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 				cmd.content.queueId,
 				(cmd: Command) => {
 					if (cmd.commandName === 'added' || cmd.commandName === 'changed') {
-						return this._commandReceiver(time, cmd.content, cmd.context, cmd.timelineObjId)
+						this.activeLayers.set(cmd.layer, JSON.stringify(cmd.content))
+						return this._commandReceiver(time, cmd.content, cmd.context, cmd.timelineObjId, cmd.layer)
 					} else {
+						this.activeLayers.delete(cmd.layer)
 						return null
 					}
 				},
@@ -213,12 +219,17 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 				return (a.content.temporalPriority || 0) - (b.content.temporalPriority || 0)
 			})
 	}
-	private _defaultCommandReceiver(
+	private async _defaultCommandReceiver(
 		_time: number,
 		cmd: HTTPSendCommandContent,
 		context: CommandContext,
-		timelineObjId: string
-	): Promise<any> {
+		timelineObjId: string,
+		layer?: string
+	): Promise<void> {
+		if (layer) {
+			const hash = this.activeLayers.get(layer)
+			if (JSON.stringify(cmd) !== hash) return Promise.resolve() // command is no longer relevant to state
+		}
 		const cwc: CommandWithContext = {
 			context: context,
 			command: cmd,
@@ -226,35 +237,35 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 		}
 		this.emit('debug', cwc)
 
-		return new Promise((resolve, reject) => {
-			const handleResponse = (error, response) => {
-				if (error) {
-					this.emit('error', `HTTPSend.response error ${cmd.type} (${context}`, error)
-					reject(error)
-				} else if (response.statusCode === 200) {
-					this.emit(
-						'debug',
-						`HTTPSend: ${cmd.type}: Good statuscode response on url "${cmd.url}": ${response.statusCode} (${context})`
-					)
-					resolve()
-				} else {
-					this.emit(
-						'warning',
-						`HTTPSend: ${cmd.type}: Bad statuscode response on url "${cmd.url}": ${response.statusCode} (${context})`
-					)
-					resolve()
-				}
-			}
+		const t = Date.now()
 
-			// send the http request:
-			const requestMethod = request[cmd.type]
-			if (requestMethod) {
-				requestMethod(cmd.url, { json: cmd.params }, handleResponse)
+		const httpReq = got[cmd.type]
+		try {
+			const response = await httpReq(cmd.url, {
+				json: cmd.type === 'post' ? cmd.params : undefined,
+			})
+
+			if (response.statusCode === 200) {
+				this.emit(
+					'debug',
+					`HTTPSend: ${cmd.type}: Good statuscode response on url "${cmd.url}": ${response.statusCode} (${context})`
+				)
 			} else {
-				reject(`Unknown HTTP-send type: "${cmd.type}"`)
+				this.emit(
+					'warning',
+					`HTTPSend: ${cmd.type}: Bad statuscode response on url "${cmd.url}": ${response.statusCode} (${context})`
+				)
 			}
-		}).catch((error) => {
+		} catch (error) {
+			this.emit('error', `HTTPSend.response error ${cmd.type} (${context}`, error)
 			this.emit('commandError', error, cwc)
-		})
+
+			if (this._resendTime) {
+				console.log('cmd error', Date.now())
+				const timeLeft = Math.max(this._resendTime - (Date.now() - t), 0)
+				await new Promise<void>((resolve) => setTimeout(() => resolve(), timeLeft))
+				this._defaultCommandReceiver(_time, cmd, context, timelineObjId, layer).catch(() => null) // errors will be emitted
+			}
+		}
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4063,7 +4063,7 @@ globby@^11.0.2, globby@^11.0.3:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-got@^11.5.2:
+got@^11.5.2, got@^11.8.2:
   version "11.8.2"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.2.tgz#7abb3959ea28c31f3576f1576c1effce23f33599"
   integrity sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Resends failed HTTP commands as long as the object stays alive
Changes the deprecated request library to the got library


* **What is the current behavior?** (You can also link to an open issue here)
HTTP commands that fail are not retried, this can cause errors on air when DNS fails.
