### PR TITLE
feat: emit more detailed slowCommands

### DIFF
--- a/packages/timeline-state-resolver/src/devices/device.ts
+++ b/packages/timeline-state-resolver/src/devices/device.ts
@@ -2,7 +2,7 @@ import * as _ from 'underscore'
 import { TimelineState } from 'superfly-timeline'
 import { Mappings, DeviceType, MediaObject, DeviceOptionsBase } from 'timeline-state-resolver-types'
 import { EventEmitter } from 'eventemitter3'
-import { CommandReport, DoOnTime } from '../doOnTime'
+import { CommandReport, DoOnTime, SlowFulfilledCommandInfo, SlowSentCommandInfo } from '../doOnTime'
 import { ExpectedPlayoutItem } from '../expectedPlayoutItems'
 
 /*
@@ -52,8 +52,14 @@ export type DeviceEvents = {
 	connectionChanged: [status: DeviceStatus]
 	/** A message to the resolver that something has happened that warrants a reset of the resolver (to re-run it again) */
 	resetResolver: []
+
 	/** A report that a command was sent too late */
 	slowCommand: [commandInfo: string]
+	/** A report that a command was sent too late */
+	slowSentCommand: [info: SlowSentCommandInfo]
+	/** A report that a command was fullfilled too late */
+	slowFulfilledCommand: [info: SlowFulfilledCommandInfo]
+
 	/** Something went wrong when executing a command  */
 	commandError: [error: Error, context: CommandWithContext]
 	/** Update a MediaObject  */
@@ -244,6 +250,8 @@ export abstract class Device<TOptions extends DeviceOptionsBase<any>>
 	protected handleDoOnTime(doOnTime: DoOnTime, deviceType: string) {
 		doOnTime.on('error', (e) => this.emit('error', `${deviceType}.doOnTime`, e))
 		doOnTime.on('slowCommand', (msg) => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		doOnTime.on('slowSentCommand', (info) => this.emit('slowSentCommand', info))
+		doOnTime.on('slowFulfilledCommand', (info) => this.emit('slowFulfilledCommand', info))
 		doOnTime.on('commandReport', (commandReport) => {
 			if (this._reportAllCommands) {
 				this.emit('commandReport', commandReport)

--- a/packages/timeline-state-resolver/src/devices/obs.ts
+++ b/packages/timeline-state-resolver/src/devices/obs.ts
@@ -86,6 +86,8 @@ export class OBSDevice extends DeviceWithState<OBSState, DeviceOptionsOBSInterna
 		)
 		this._doOnTime.on('error', (e) => this.emit('error', 'OBS.doOnTime', e))
 		this._doOnTime.on('slowCommand', (msg) => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this._doOnTime.on('slowSentCommand', (info) => this.emit('slowSentCommand', info))
+		this._doOnTime.on('slowFulfilledCommand', (info) => this.emit('slowFulfilledCommand', info))
 	}
 	init(options: OBSOptions): Promise<boolean> {
 		this._options = options

--- a/packages/timeline-state-resolver/src/devices/vmix.ts
+++ b/packages/timeline-state-resolver/src/devices/vmix.ts
@@ -88,6 +88,8 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 		)
 		this._doOnTime.on('error', (e) => this.emit('error', 'VMix.doOnTime', e))
 		this._doOnTime.on('slowCommand', (msg) => this.emit('slowCommand', this.deviceName + ': ' + msg))
+		this._doOnTime.on('slowSentCommand', (info) => this.emit('slowSentCommand', info))
+		this._doOnTime.on('slowFulfilledCommand', (info) => this.emit('slowFulfilledCommand', info))
 	}
 	init(options: VMixOptions): Promise<boolean> {
 		this._vmix = new VMix()

--- a/packages/timeline-state-resolver/src/doOnTime.ts
+++ b/packages/timeline-state-resolver/src/doOnTime.ts
@@ -19,7 +19,31 @@ interface DoOrder {
 export type DoOnTimeEvents = {
 	error: [err: Error]
 	slowCommand: [commandInfo: string]
+	slowSentCommand: [info: SlowSentCommandInfo]
+	slowFulfilledCommand: [info: SlowFulfilledCommandInfo]
 	commandReport: [commandReport: CommandReport]
+}
+
+export interface SlowSentCommandInfo {
+	added: number
+	prepareTime: number
+	plannedSend: number
+	send: number
+	queueId: string
+	args: string
+	sendDelay: number
+	addedDelay: number
+	internalDelay: number
+}
+export interface SlowFulfilledCommandInfo {
+	added: number
+	prepareTime: number
+	plannedSend: number
+	send: number
+	queueId: string
+	fullfilled: number
+	fulfilledDelay: number
+	args: string
 }
 
 export enum SendMode {
@@ -223,26 +247,35 @@ export class DoOnTime extends EventEmitter<DoOnTimeEvents> {
 		}
 	}
 	private _verifySendCommand(o: DoOrder, send: number, queueId: string): boolean {
+		const sendDelay: number = send - o.time
+		const addedDelay: number = o.time - o.addedTime
+		const internalDelay = send - o.addedTime
+
 		if (this._options.limitSlowSentCommand) {
-			const sendDelay: number = send - o.time
-			const addedDelay: number = o.time - o.addedTime
 			if (sendDelay > this._options.limitSlowSentCommand) {
-				const output = {
+				const output: SlowSentCommandInfo = {
 					added: o.addedTime,
 					prepareTime: o.prepareTime,
 					plannedSend: o.time,
 					send: send,
 					queueId: queueId,
-					args: this.representArguments(o),
+					sendDelay,
+					addedDelay,
+					internalDelay,
+					args: JSON.stringify(this.representArguments(o)),
 				}
+				this.emit('slowSentCommand', output)
+				// Keep the old one, for backwards compatibility:
 				this.emit(
 					'slowCommand',
 					`Slow sent command, should have been sent at ${o.time}, was ${sendDelay} ms slow (was added ${
 						addedDelay >= 0 ? `${addedDelay} ms before` : `${-addedDelay} ms after`
-					} planned), sendMode: ${SendMode[this._sendMode]}. Command: ${JSON.stringify(output)}`
+					} planned), sendMode: ${SendMode[this._sendMode]}. Command: ${output.args}`
 				)
-				return true
 			}
+		}
+		if (this._options.limitSlowSentCommand && sendDelay > this._options.limitSlowSentCommand) {
+			return true
 		}
 		return false
 	}
@@ -250,21 +283,22 @@ export class DoOnTime extends EventEmitter<DoOnTimeEvents> {
 		if (this._options.limitSlowFulfilledCommand) {
 			const fullfilled = this.getCurrentTime()
 			const fulfilledDelay: number = fullfilled - o.time
-			const output = {
-				added: o.addedTime,
-				prepareTime: o.prepareTime,
-				plannedSend: o.time,
-				send: send,
-				queueId: queueId,
-				fullfilled: fullfilled,
-				args: this.representArguments(o),
-			}
 			if (fulfilledDelay > this._options.limitSlowFulfilledCommand) {
+				const output: SlowFulfilledCommandInfo = {
+					added: o.addedTime,
+					prepareTime: o.prepareTime,
+					plannedSend: o.time,
+					send: send,
+					queueId: queueId,
+					fullfilled: fullfilled,
+					fulfilledDelay,
+					args: JSON.stringify(this.representArguments(o)),
+				}
+				this.emit('slowFulfilledCommand', output)
+				// Keep the old one, for backwards compatibility:
 				this.emit(
 					'slowCommand',
-					`Slow fulfilled command, should have been fulfilled at ${
-						o.time
-					}, was ${fulfilledDelay} ms slow. Command: ${JSON.stringify(output)}`
+					`Slow fulfilled command, should have been fulfilled at ${o.time}, was ${fulfilledDelay} ms slow. Command: ${output.args}`
 				)
 			}
 		}


### PR DESCRIPTION
This PR adds some more emit events, that'll be used in Playout Gateway to log more filtered and detailed info about slow commands.

It is used in Playout Gateway in this PR: https://github.com/nrkno/tv-automation-server-core/pull/566