### PR TITLE
fix: wait for releaseing quantel port before creating a new one

### DIFF
--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -106,7 +106,7 @@
     "threadedclass": "0.8.3",
     "timeline-state-resolver-types": "6.2.0-release37.1",
     "tslib": "^2.3.1",
-    "tv-automation-quantel-gateway-client": "^1.0.12",
+    "tv-automation-quantel-gateway-client": "^2.0.4",
     "underscore": "^1.12.0",
     "underscore-deep-extend": "^1.1.5",
     "utf-8-validate": "^5.0.2",

--- a/packages/timeline-state-resolver/src/devices/quantel.ts
+++ b/packages/timeline-state-resolver/src/devices/quantel.ts
@@ -98,15 +98,18 @@ export class QuantelDevice extends DeviceWithState<QuantelState, DeviceOptionsQu
 
 	async init(initOptions: QuantelOptions): Promise<boolean> {
 		this._initOptions = initOptions
-		const ISAUrlMaster = this._initOptions.ISAUrlMaster || this._initOptions['ISAUrl'] // tmp: ISAUrl for backwards compatibility, to be removed later
+		const ISAUrlMaster: string = this._initOptions.ISAUrlMaster || this._initOptions['ISAUrl'] // tmp: ISAUrl for backwards compatibility, to be removed later
 		if (!this._initOptions.gatewayUrl) throw new Error('Quantel bad connection option: gatewayUrl')
 		if (!ISAUrlMaster) throw new Error('Quantel bad connection option: ISAUrlMaster')
 		if (!this._initOptions.serverId) throw new Error('Quantel bad connection option: serverId')
 
+		const isaURLs: string[] = []
+		if (ISAUrlMaster) isaURLs.push(ISAUrlMaster)
+		if (this._initOptions.ISAUrlBackup) isaURLs.push(this._initOptions.ISAUrlBackup)
+
 		await this._quantel.init(
 			this._initOptions.gatewayUrl,
-			ISAUrlMaster,
-			this._initOptions.ISAUrlBackup,
+			isaURLs,
 			this._initOptions.zoneId,
 			this._initOptions.serverId
 		)
@@ -195,7 +198,11 @@ export class QuantelDevice extends DeviceWithState<QuantelState, DeviceOptionsQu
 		return DeviceType.QUANTEL
 	}
 	get deviceName(): string {
-		return `Quantel ${this._quantel.ISAUrl}/${this._quantel.zoneId}/${this._quantel.serverId}`
+		try {
+			return `Quantel ${this._quantel.ISAUrl}/${this._quantel.zoneId}/${this._quantel.serverId}`
+		} catch (e) {
+			return `Quantel device (uninitialized)`
+		}
 	}
 
 	get queue() {

--- a/packages/timeline-state-resolver/src/devices/quantel.ts
+++ b/packages/timeline-state-resolver/src/devices/quantel.ts
@@ -624,7 +624,10 @@ export class QuantelDevice extends DeviceWithState<QuantelState, DeviceOptionsQu
 				throw new Error(`Unsupported command type "${cmdType}"`)
 			}
 		} catch (error) {
-			const errorString = error && error.message ? error.message : error.toString()
+			let errorString = error && error.message ? error.message : error.toString()
+			if (error?.stack) {
+				errorString += error.stack
+			}
 			this.emit('commandError', new Error(errorString), cwc)
 		}
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4092,7 +4092,7 @@ globby@^11.0.2, globby@^11.0.3:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-got@^11.5.2, got@^11.8.2:
+got@^11.8.2:
   version "11.8.2"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.2.tgz#7abb3959ea28c31f3576f1576c1effce23f33599"
   integrity sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==
@@ -8352,13 +8352,12 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tv-automation-quantel-gateway-client@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/tv-automation-quantel-gateway-client/-/tv-automation-quantel-gateway-client-1.0.12.tgz#2856a2d8459a9fe21c2eb12f54ecea471db3e930"
-  integrity sha512-yab4tXDifQAZhLRl+t03zSnSlu/N3Zh9zGHs5c3b1OuRSHTEFZqHIt6jnXVsxzHfLSTo2NYV5T5f8o4GmMVhIQ==
+tv-automation-quantel-gateway-client@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/tv-automation-quantel-gateway-client/-/tv-automation-quantel-gateway-client-2.0.4.tgz#c130cca5e953a4749226ddedad672fc3de9e1d84"
+  integrity sha512-ETw+Zrusv6aMoZz1qfxsHaQ1q5SCXocN1IBOdAZ7NHW1Yw1+QCm10LXXh8OuL8iyaHx9GKbIsYOAAYYpLM9j6w==
   dependencies:
-    got "^11.5.2"
-    underscore "^1.9.1"
+    got "^11.8.2"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes a potential bug in the Quantel device.


* **What is the current behavior?** (You can also link to an open issue here)
When renaming a port, there is sent `releasePort` and `getPort+createPort` in parallel, causing us to get errors from Quantel Gateway in the `createPort` function.


* **What is the new behavior (if this is a feature change)?**
This PR makes TSR wait for any `releasePort` to finish (on that channel) before setting up a new port.


* **Other information**:
