### PR TITLE
fix: add missing atem-type to TimelineObjAtemAny

### DIFF
--- a/packages/timeline-state-resolver-types/src/__tests__/library.spec.ts
+++ b/packages/timeline-state-resolver-types/src/__tests__/library.spec.ts
@@ -1,5 +1,4 @@
 // These imports are pointed to what external libraries will import
-// eslint-disable-next-line
 import { DeviceType as Types_DeviceType, TSRTimeline, TimelineObjEmpty } from '../../dist'
 
 describe('Usage of library', () => {

--- a/packages/timeline-state-resolver-types/src/__tests__/library.spec.ts
+++ b/packages/timeline-state-resolver-types/src/__tests__/library.spec.ts
@@ -1,4 +1,5 @@
 // These imports are pointed to what external libraries will import
+// eslint-disable-next-line
 import { DeviceType as Types_DeviceType, TSRTimeline, TimelineObjEmpty } from '../../dist'
 
 describe('Usage of library', () => {

--- a/packages/timeline-state-resolver-types/src/atem.ts
+++ b/packages/timeline-state-resolver-types/src/atem.ts
@@ -114,6 +114,7 @@ export type TimelineObjAtemAny =
 	| TimelineObjAtemSsrc
 	| TimelineObjAtemSsrcProps
 	| TimelineObjAtemMacroPlayer
+	| TimelineObjAtemAudioChannel
 	| TimelineObjAtemMediaPlayer
 export interface TimelineObjAtemBase extends TSRTimelineObjBase {
 	content: {


### PR DESCRIPTION
Add missing type `TimelineObjAtemAudioChannel` to `TimelineObjAtemAny`