### PR TITLE
Fix: casparCG template transitions bug

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -430,7 +430,6 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 			switch (baseContent.type) {
 				case TimelineContentTypeCasparCg.MEDIA:
 				case TimelineContentTypeCasparCg.IP:
-				case TimelineContentTypeCasparCg.TEMPLATE:
 				case TimelineContentTypeCasparCg.INPUT:
 				case TimelineContentTypeCasparCg.ROUTE:
 				case TimelineContentTypeCasparCg.HTMLPAGE: {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.

CasparCG Templates doesn't actually support transitions, but we have code paths that support it (but apparently they are buggy).


* **What is the current behavior?** (You can also link to an open issue here)
When playing a template object, and (accidentally) has set a transition for it, the template isn't played properly.
(when stopped, a PLAY "empty" is sent, not a CG STOP)


* **What is the new behavior (if this is a feature change)?**
CG PLAY and CG STOP are sent, as they should


* **Other information**:


TODO

- [ ] Verify that this is actually the right thing to do, and that templates actually does not and should not support transitions
