### PR TITLE
fix: if a state older than the `currentState` is put into `handleState`, a B-A-B sequence of state changes can happen (SOFIE-3889)

### DIFF
--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -109,7 +109,7 @@
 		"p-timeout": "^3.2.0",
 		"simple-oauth2": "^5.0.0",
 		"sprintf-js": "^1.1.3",
-		"superfly-timeline": "9.0.2",
+		"superfly-timeline": "9.1.2",
 		"threadedclass": "^1.2.1",
 		"timeline-state-resolver-types": "9.2.0",
 		"tslib": "^2.6.2",

--- a/packages/timeline-state-resolver/src/service/stateHandler.ts
+++ b/packages/timeline-state-resolver/src/service/stateHandler.ts
@@ -144,7 +144,11 @@ export class StateHandler<DeviceState, Command extends CommandWithContext> {
 			nextState.commands = []
 		}
 
-		if (nextState.state.time - (nextState.preliminary ?? 0) <= this.context.getCurrentTime() && this.currentState) {
+		if (
+			nextState === this.stateQueue[0] &&
+			nextState.state.time - (nextState.preliminary ?? 0) <= this.context.getCurrentTime() &&
+			this.currentState
+		) {
 			await this.executeNextStateChange()
 		}
 	}

--- a/packages/timeline-state-resolver/src/service/stateHandler.ts
+++ b/packages/timeline-state-resolver/src/service/stateHandler.ts
@@ -111,8 +111,8 @@ export class StateHandler<DeviceState, Command extends CommandWithContext> {
 		this.currentState = {
 			commands: [],
 			deviceState: state,
-			state: this.currentState?.state || { time: this.context.getCurrentTime(), layers: {}, nextEvents: [] },
-			mappings: this.currentState?.mappings || {},
+			state: this.currentState?.state ?? { time: this.context.getCurrentTime(), layers: {}, nextEvents: [] },
+			mappings: this.currentState?.mappings ?? {},
 		}
 		await this.calculateNextStateChange()
 	}

--- a/packages/timeline-state-resolver/src/service/stateHandler.ts
+++ b/packages/timeline-state-resolver/src/service/stateHandler.ts
@@ -145,7 +145,7 @@ export class StateHandler<DeviceState, Command extends CommandWithContext> {
 		}
 
 		if (
-			this._executingStateChange && // make sure we're not trying to loop onto ourselves
+			!this._executingStateChange &&
 			nextState === this.stateQueue[0] &&
 			nextState.state.time - (nextState.preliminary ?? 0) <= this.context.getCurrentTime()
 		) {

--- a/packages/timeline-state-resolver/src/service/stateHandler.ts
+++ b/packages/timeline-state-resolver/src/service/stateHandler.ts
@@ -77,6 +77,8 @@ export class StateHandler<DeviceState, Command extends CommandWithContext> {
 	}
 
 	async handleState(state: Timeline.TimelineState<TSRTimelineContent>, mappings: Mappings) {
+		if (this.currentState?.state && this.currentState.state.time > state.time) return // the incoming state is stale, we ignore it
+
 		const nextState = this.stateQueue[0]
 
 		const trace = startTrace('device:convertTimelineStateToDeviceState', { deviceId: this.context.deviceId })

--- a/packages/timeline-state-resolver/src/service/stateHandler.ts
+++ b/packages/timeline-state-resolver/src/service/stateHandler.ts
@@ -145,9 +145,9 @@ export class StateHandler<DeviceState, Command extends CommandWithContext> {
 		}
 
 		if (
+			this._executingStateChange && // make sure we're not trying to loop onto ourselves
 			nextState === this.stateQueue[0] &&
-			nextState.state.time - (nextState.preliminary ?? 0) <= this.context.getCurrentTime() &&
-			this.currentState
+			nextState.state.time - (nextState.preliminary ?? 0) <= this.context.getCurrentTime()
 		) {
 			await this.executeNextStateChange()
 		}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11110,12 +11110,12 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"superfly-timeline@npm:9.0.2":
-  version: 9.0.2
-  resolution: "superfly-timeline@npm:9.0.2"
+"superfly-timeline@npm:9.1.2":
+  version: 9.1.2
+  resolution: "superfly-timeline@npm:9.1.2"
   dependencies:
     tslib: ^2.6.0
-  checksum: d628d467d5384f5667bc10b877478c5b8b0a91774b5d5c5e9d9d3134b8f1b760225f2fbbb0f9ccd3e55f930c9f3719f81b9347b94ea853fbc0a18bc121d97665
+  checksum: c195d3e65fd3d63223dd2a008facb32850b71da0355b258c0a08e1417bd447b144e01088f28e8e71fe8c240885c2bc5f73e8df7c84f131e963521510edf8bde2
   languageName: node
   linkType: hard
 
@@ -11415,7 +11415,7 @@ asn1@evs-broadcast/node-asn1:
     p-timeout: ^3.2.0
     simple-oauth2: ^5.0.0
     sprintf-js: ^1.1.3
-    superfly-timeline: 9.0.2
+    superfly-timeline: 9.1.2
     threadedclass: ^1.2.1
     timeline-state-resolver-types: 9.2.0
     tslib: ^2.6.2


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: 
<!-- (pick one) -->
Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
In some cases, states will go into the `StateHandler` out of order, with `state.time` less than the `currentState.time`. This will cause additional commands to be issued and the state of the device going B-A-B, where B is the expected target state, and A is a previous, older state.




## New Behavior
<!--
What is the new behavior?
-->
States older than `currentState` will be ignored.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->
* See if the B-A-B pattern can be reproduced. If not, then this is tested successfully.


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->
This attempts to fix the same issue as https://github.com/nrkno/sofie-timeline-state-resolver/pull/374


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
