### PR TITLE
Fix (Quantel) Reimplement CANCELWAITING port commands (SOFIE-3551)

### DIFF
--- a/packages/timeline-state-resolver/src/__tests__/mockTime.ts
+++ b/packages/timeline-state-resolver/src/__tests__/mockTime.ts
@@ -22,6 +22,9 @@ export class MockTime {
 		this._now = 10000
 		jest.useFakeTimers({ now: this._now })
 	}
+	reset = () => {
+		jest.useRealTimers()
+	}
 	advanceTime = (advanceTime: number) => {
 		this._now += advanceTime
 		jest.advanceTimersByTime(advanceTime)

--- a/packages/timeline-state-resolver/src/integrations/quantel/__tests__/quantel.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/quantel/__tests__/quantel.spec.ts
@@ -8,6 +8,7 @@ import {
 	SomeMappingQuantel,
 	Timeline,
 	TimelineContentQuantelAny,
+	TSRTimeline,
 	TSRTimelineContent,
 } from 'timeline-state-resolver-types'
 import { QuantelCommandWithContext, QuantelDevice } from '..'
@@ -15,6 +16,11 @@ import { QuantelCommandType, QuantelState } from '../types'
 import { setupQuantelGatewayMock } from './quantelGatewayMock'
 import { MockTime } from '../../../__tests__/mockTime'
 import { getDeviceContext } from '../../../integrations/__tests__/testlib'
+import { StateHandler } from '../../../service/stateHandler'
+import { CommandWithContext } from '../../..'
+import { getResolvedState, resolveTimeline } from 'superfly-timeline'
+import { DevicesDict } from '../../../service/devices'
+import { setSoftJumpWaitTime } from '../connection'
 
 async function getInitialisedQuantelDevice(clearMock?: jest.Mock) {
 	const dev = new QuantelDevice(getDeviceContext())
@@ -417,6 +423,16 @@ describe('Quantel Device', () => {
 				[
 					{
 						command: {
+							type: QuantelCommandType.CANCELWAITING,
+							portId: 'port0',
+							timelineObjId: '',
+						},
+						context: 'Clear all delayed out-transitions',
+						queueId: 'reset_port_port0',
+						timelineObjId: '',
+					},
+					{
+						command: {
 							type: QuantelCommandType.SETUPPORT,
 							portId: 'port0',
 							timelineObjId: 'obj0',
@@ -475,6 +491,16 @@ describe('Quantel Device', () => {
 				[
 					{
 						command: {
+							type: QuantelCommandType.CANCELWAITING,
+							portId: 'port0',
+							timelineObjId: '',
+						},
+						context: 'Clear all delayed out-transitions',
+						queueId: 'reset_port_port0',
+						timelineObjId: '',
+					},
+					{
+						command: {
 							type: QuantelCommandType.LOADCLIPFRAGMENTS,
 							portId: 'port0',
 							timelineObjId: 'obj1',
@@ -505,6 +531,7 @@ describe('Quantel Device', () => {
 							mode: QuantelControlMode.QUALITY,
 							transition: undefined,
 						},
+						preliminary: undefined,
 						context: 'New clip is paused',
 						timelineObjId: 'obj1',
 					},
@@ -546,6 +573,16 @@ describe('Quantel Device', () => {
 				[
 					{
 						command: {
+							type: QuantelCommandType.CANCELWAITING,
+							portId: 'port0',
+							timelineObjId: '',
+						},
+						context: 'Clear all delayed out-transitions',
+						queueId: 'reset_port_port0',
+						timelineObjId: '',
+					},
+					{
+						command: {
 							type: QuantelCommandType.LOADCLIPFRAGMENTS,
 							portId: 'port0',
 							timelineObjId: 'obj1',
@@ -578,6 +615,7 @@ describe('Quantel Device', () => {
 						},
 						context: 'New clip is paused',
 						timelineObjId: 'obj1',
+						preliminary: undefined,
 					},
 				]
 			)
@@ -622,6 +660,16 @@ describe('Quantel Device', () => {
 				[
 					{
 						command: {
+							type: QuantelCommandType.CANCELWAITING,
+							portId: 'port0',
+							timelineObjId: '',
+						},
+						context: 'Clear all delayed out-transitions',
+						queueId: 'reset_port_port0',
+						timelineObjId: '',
+					},
+					{
+						command: {
 							type: QuantelCommandType.LOADCLIPFRAGMENTS,
 							portId: 'port0',
 							timelineObjId: 'obj1',
@@ -654,6 +702,7 @@ describe('Quantel Device', () => {
 						},
 						context: 'New clip is playing',
 						timelineObjId: 'obj1',
+						preliminary: undefined,
 					},
 				]
 			)
@@ -698,6 +747,16 @@ describe('Quantel Device', () => {
 				[
 					{
 						command: {
+							type: QuantelCommandType.CANCELWAITING,
+							portId: 'port0',
+							timelineObjId: '',
+						},
+						context: 'Clear all delayed out-transitions',
+						queueId: 'reset_port_port0',
+						timelineObjId: '',
+					},
+					{
+						command: {
 							type: QuantelCommandType.LOADCLIPFRAGMENTS,
 							portId: 'port0',
 							timelineObjId: 'obj1',
@@ -730,6 +789,7 @@ describe('Quantel Device', () => {
 						},
 						context: 'New clip is playing',
 						timelineObjId: 'obj1',
+						preliminary: undefined,
 					},
 				]
 			)
@@ -756,6 +816,16 @@ describe('Quantel Device', () => {
 				},
 				{ time: 3000, port: {} },
 				[
+					{
+						command: {
+							type: QuantelCommandType.CANCELWAITING,
+							portId: 'port0',
+							timelineObjId: '',
+						},
+						context: 'Clear all delayed out-transitions',
+						queueId: 'reset_port_port0',
+						timelineObjId: '',
+					},
 					{
 						command: {
 							type: QuantelCommandType.RELEASEPORT,
@@ -810,6 +880,16 @@ describe('Quantel Device', () => {
 				[
 					{
 						command: {
+							type: QuantelCommandType.CANCELWAITING,
+							portId: 'port0',
+							timelineObjId: '',
+						},
+						context: 'Clear all delayed out-transitions',
+						queueId: 'reset_port_port0',
+						timelineObjId: '',
+					},
+					{
+						command: {
 							type: QuantelCommandType.LOADCLIPFRAGMENTS,
 							portId: 'port0',
 							timelineObjId: 'obj2',
@@ -842,6 +922,7 @@ describe('Quantel Device', () => {
 						},
 						context: 'New clip is playing',
 						timelineObjId: 'obj2',
+						preliminary: undefined,
 					},
 				],
 				15020
@@ -886,6 +967,16 @@ describe('Quantel Device', () => {
 						},
 					},
 					[
+						{
+							command: {
+								type: QuantelCommandType.CANCELWAITING,
+								portId: 'port0',
+								timelineObjId: '',
+							},
+							context: 'Clear all delayed out-transitions',
+							queueId: 'reset_port_port0',
+							timelineObjId: '',
+						},
 						{
 							command: {
 								type: QuantelCommandType.CLEARCLIP,
@@ -948,6 +1039,16 @@ describe('Quantel Device', () => {
 					[
 						{
 							command: {
+								type: QuantelCommandType.CANCELWAITING,
+								portId: 'port0',
+								timelineObjId: '',
+							},
+							context: 'Clear all delayed out-transitions',
+							queueId: 'reset_port_port0',
+							timelineObjId: '',
+						},
+						{
+							command: {
 								type: QuantelCommandType.LOADCLIPFRAGMENTS,
 								portId: 'port0',
 								timelineObjId: 'obj2',
@@ -983,6 +1084,7 @@ describe('Quantel Device', () => {
 							},
 							context: 'New clip is paused',
 							timelineObjId: 'obj2',
+							preliminary: undefined,
 						},
 					],
 					11500
@@ -1033,6 +1135,16 @@ describe('Quantel Device', () => {
 					[
 						{
 							command: {
+								type: QuantelCommandType.CANCELWAITING,
+								portId: 'port0',
+								timelineObjId: '',
+							},
+							context: 'Clear all delayed out-transitions',
+							queueId: 'reset_port_port0',
+							timelineObjId: '',
+						},
+						{
+							command: {
 								type: QuantelCommandType.LOADCLIPFRAGMENTS,
 								portId: 'port0',
 								timelineObjId: 'obj2',
@@ -1065,6 +1177,7 @@ describe('Quantel Device', () => {
 							},
 							context: 'New clip is paused',
 							timelineObjId: 'obj2',
+							preliminary: undefined,
 						},
 					],
 					11500
@@ -1097,6 +1210,26 @@ describe('Quantel Device', () => {
 					},
 				},
 				[
+					{
+						command: {
+							type: QuantelCommandType.CANCELWAITING,
+							portId: 'port0_renamed',
+							timelineObjId: '',
+						},
+						context: 'Clear all delayed out-transitions',
+						queueId: 'reset_port_port0_renamed',
+						timelineObjId: '',
+					},
+					{
+						command: {
+							type: QuantelCommandType.CANCELWAITING,
+							portId: 'port0',
+							timelineObjId: '',
+						},
+						context: 'Clear all delayed out-transitions',
+						queueId: 'reset_port_port0',
+						timelineObjId: '',
+					},
 					{
 						command: {
 							type: QuantelCommandType.RELEASEPORT,
@@ -1140,6 +1273,9 @@ describe('Quantel Device', () => {
 		const mockTime = new MockTime()
 		beforeAll(() => {
 			mockTime.init()
+		})
+		afterAll(() => {
+			mockTime.reset()
 		})
 
 		test('sequence of commands', async () => {
@@ -1304,6 +1440,539 @@ describe('Quantel Device', () => {
 			expect(onRequest).toHaveBeenNthCalledWith(1, 'post', expect.stringContaining('port/my_port/reset'))
 		})
 	})
+	describe('with StateHandler', () => {
+		const MOCK_SEND_COMMAND = jest.fn()
+		const CONTEXT = {
+			deviceId: 'unitTests0',
+			logger: {
+				debug: console.log,
+				info: console.log,
+				warn: console.log,
+				error: console.log,
+			},
+			emitTimeTrace: () => null,
+			reportStateChangeMeasurement: () => null,
+			getCurrentTime: () => Date.now(),
+		}
+		function getNewStateHandler(device: QuantelDevice): StateHandler<QuantelState, CommandWithContext<any, any>> {
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			const orgSendCommand = device.sendCommand
+			device.sendCommand = async function mockFunction(...args) {
+				MOCK_SEND_COMMAND(...args)
+				return orgSendCommand.apply(device, args)
+			}
+
+			const deviceSpecs = DevicesDict[DeviceType.QUANTEL]
+			return new StateHandler<QuantelState, CommandWithContext<any, any>>(
+				CONTEXT,
+				{
+					executionType: deviceSpecs.executionMode({}),
+				},
+				device
+			)
+		}
+		function clearMocks() {
+			MOCK_SEND_COMMAND.mockClear()
+			onRequest.mockClear()
+		}
+		beforeAll(() => {
+			setSoftJumpWaitTime(0)
+		})
+
+		test('outTransition to clear, cancel, then play another', async () => {
+			const device = await getInitialisedQuantelDevice()
+
+			// give it some time to finish the init
+			await sleep(10)
+
+			const stateHandler = getNewStateHandler(device)
+
+			const now = Date.now()
+
+			const timeline: TSRTimeline = [
+				{
+					id: 'obj0',
+					enable: {
+						start: now + 100,
+						end: now + 200,
+					},
+					content: {
+						deviceType: DeviceType.QUANTEL,
+						title: 'myClip0',
+						outTransition: {
+							type: QuantelTransitionType.DELAY,
+							delay: 500, // 2500
+						},
+					},
+					layer: 'layer0',
+				},
+				{
+					id: 'obj1',
+					enable: {
+						start: now + 210,
+						end: now + 1000,
+					},
+					content: {
+						deviceType: DeviceType.QUANTEL,
+						title: 'myClip1',
+					},
+					layer: 'layer0',
+				},
+			]
+			const mappings: Mappings = {
+				layer0: {
+					device: DeviceType.QUANTEL,
+					deviceId: 'quantel0',
+					options: {
+						mappingType: MappingQuantelType.Port,
+						portId: 'my_port',
+						channelId: 1,
+					},
+				},
+			}
+
+			const resolved = resolveTimeline(timeline, {
+				time: now,
+			})
+
+			// Handle state at time 0 (nothing is playing)
+			{
+				const state = getResolvedState(resolved, now)
+				await stateHandler.handleState(state, mappings)
+
+				// Give QuantelManager some time to process the commands
+				await sleep(10)
+				expect(MOCK_SEND_COMMAND).toHaveBeenCalledTimes(3)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					1,
+					expect.objectContaining({
+						command: expect.objectContaining({ type: QuantelCommandType.CANCELWAITING, portId: 'my_port' }),
+					})
+				)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					2,
+					expect.objectContaining({
+						command: expect.objectContaining({ type: QuantelCommandType.SETUPPORT, portId: 'my_port', channel: 1 }),
+					})
+				)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					3,
+					expect.objectContaining({
+						command: expect.objectContaining({ type: QuantelCommandType.CLEARCLIP, portId: 'my_port' }),
+					})
+				)
+
+				expect(onRequest).toHaveBeenCalledWith('post', 'http://localhost:3000/connect/myISA%3A8000')
+				expect(onRequest).toHaveBeenCalledWith('get', 'http://localhost:3000/default/server')
+				expect(onRequest).toHaveBeenCalledWith('get', 'http://localhost:3000/default/server/1100/port/my_port')
+				expect(onRequest).toHaveBeenCalledWith(
+					'put',
+					'http://localhost:3000/default/server/1100/port/my_port/channel/1'
+				)
+				expect(onRequest).toHaveBeenCalledWith('post', 'http://localhost:3000/default/server/1100/port/my_port/reset')
+				clearMocks()
+			}
+
+			// Handle state at time 1000 (myClip0 starts to play)
+			{
+				const state = getResolvedState(resolved, now + 100)
+				await stateHandler.handleState(state, mappings)
+				// Give QuantelManager some time to process the commands
+				await sleep(200)
+
+				expect(MOCK_SEND_COMMAND).toHaveBeenCalledTimes(3)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					1,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.CANCELWAITING,
+							portId: 'my_port',
+						}),
+					})
+				)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					2,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.LOADCLIPFRAGMENTS,
+							portId: 'my_port',
+							clip: expect.objectContaining({ title: 'myClip0' }),
+						}),
+					})
+				)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					3,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.PLAYCLIP,
+							portId: 'my_port',
+							clip: expect.objectContaining({ title: 'myClip0' }),
+						}),
+					})
+				)
+
+				expect(onRequest).toHaveBeenCalledWith('post', expect.stringContaining('/1100/port/my_port/fragments?offset=0'))
+				// expect(onRequest).toHaveBeenCalledWith('put', expect.stringContaining('/1100/port/my_port/jump?offset='))
+				// expect(onRequest).toHaveBeenCalledWith('post', expect.stringContaining('/1100/port/my_port/trigger/JUMP'))
+				expect(onRequest).toHaveBeenCalledWith('get', expect.stringContaining('/1100/port/my_port'))
+				expect(onRequest).toHaveBeenCalledWith('post', expect.stringContaining('/1100/port/my_port/trigger/START'))
+				expect(onRequest).toHaveBeenCalledWith(
+					'post',
+					expect.stringContaining('/1100/port/my_port/trigger/STOP?offset=1999')
+				)
+
+				clearMocks()
+			}
+			// Handle state at time 2000 (myClip0 should stop (but is delayed due to outTransition))
+			{
+				const state = getResolvedState(resolved, now + 200)
+				await stateHandler.handleState(state, mappings)
+				// Give QuantelManager some time to process the commands
+				await sleep(100)
+
+				expect(MOCK_SEND_COMMAND).toHaveBeenCalledTimes(2)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					1,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.CANCELWAITING,
+							portId: 'my_port',
+						}),
+					})
+				)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					2,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.CLEARCLIP,
+							portId: 'my_port',
+							transition: { type: QuantelTransitionType.DELAY, delay: 500 },
+						}),
+					})
+				)
+
+				// Since the clear is delayed, we should not have sent any commands:
+
+				expect(onRequest).toHaveBeenCalledTimes(0)
+
+				clearMocks()
+			}
+			// Handle state at time 2100 (myClip1 starts playing)
+			{
+				const state = getResolvedState(resolved, now + 210)
+				await stateHandler.handleState(state, mappings)
+
+				// Wait enough time to ensure that the outTransition from previous clip would have finished (had it not been cancelled)
+				await sleep(100)
+
+				expect(MOCK_SEND_COMMAND).toHaveBeenCalledTimes(3)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					1,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.CANCELWAITING,
+							portId: 'my_port',
+						}),
+					})
+				)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					2,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.LOADCLIPFRAGMENTS,
+							portId: 'my_port',
+							clip: expect.objectContaining({ title: 'myClip1' }),
+						}),
+					})
+				)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					3,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.PLAYCLIP,
+							portId: 'my_port',
+							clip: expect.objectContaining({ title: 'myClip1' }),
+						}),
+					})
+				)
+				// Start playing of next clip:
+				expect(onRequest).toHaveBeenCalledWith(
+					'post',
+					expect.stringContaining('/1100/port/my_port/fragments?offset=2000')
+				)
+				expect(onRequest).toHaveBeenCalledWith('put', expect.stringContaining('/1100/port/my_port/jump?offset='))
+				expect(onRequest).toHaveBeenCalledWith('post', expect.stringContaining('/1100/port/my_port/trigger/JUMP'))
+				expect(onRequest).toHaveBeenCalledWith('post', expect.stringContaining('/1100/port/my_port/trigger/START'))
+				expect(onRequest).toHaveBeenCalledWith('get', expect.stringContaining('/1100/port/my_port'))
+				expect(onRequest).toHaveBeenCalledWith(
+					'post',
+					expect.stringContaining('/1100/port/my_port/trigger/STOP?offset=3233')
+				)
+				// The first clip should NOT have stopped, as it was delayed and cancelled:
+				expect(onRequest).not.toHaveBeenCalledWith('post', expect.stringMatching(/trigger\/STOP$/))
+
+				clearMocks()
+			}
+			await device.terminate()
+		})
+		test('outTransition to lookahead, cancel, then play another', async () => {
+			const dev = await getInitialisedQuantelDevice()
+
+			// give it some time to finish the init
+			await sleep(10)
+
+			const now = Date.now()
+
+			const stateHandler = getNewStateHandler(dev)
+
+			const timeline: TSRTimeline = [
+				{
+					id: 'obj0',
+					enable: {
+						start: now + 100,
+						end: now + 200,
+					},
+					content: {
+						deviceType: DeviceType.QUANTEL,
+						title: 'myClip0',
+						outTransition: {
+							type: QuantelTransitionType.DELAY,
+							delay: 500, // 2500
+						},
+					},
+					layer: 'layer0',
+				},
+				{
+					id: 'obj0_lookahead',
+					enable: {
+						start: '#obj0.end',
+						end: '#obj1.start',
+					},
+					content: {
+						deviceType: DeviceType.QUANTEL,
+						title: 'myClip0',
+						// outTransition: {
+						// 	type: QuantelTransitionType.DELAY,
+						// 	delay: 1000, // 3000
+						// },
+					},
+					layer: 'layer0_lookahead',
+					lookaheadForLayer: 'layer0',
+					isLookahead: true,
+				},
+				{
+					id: 'obj1',
+					enable: {
+						start: now + 210,
+						end: now + 1000,
+					},
+					content: {
+						deviceType: DeviceType.QUANTEL,
+						title: 'myClip1',
+					},
+					layer: 'layer0',
+				},
+			]
+			const mappings: Mappings = {
+				layer0: {
+					device: DeviceType.QUANTEL,
+					deviceId: 'quantel0',
+					options: {
+						mappingType: MappingQuantelType.Port,
+						portId: 'my_port',
+						channelId: 1,
+					},
+				},
+			}
+			const resolved = resolveTimeline(timeline, { time: now })
+
+			// Handle state at time 0 (nothing is playing)
+			{
+				const state = getResolvedState(resolved, now)
+
+				await stateHandler.handleState(state, mappings)
+
+				// Give QuantelManager some time to process the commands
+
+				await sleep(100)
+
+				expect(MOCK_SEND_COMMAND).toHaveBeenCalledTimes(3)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					1,
+					expect.objectContaining({
+						command: expect.objectContaining({ type: QuantelCommandType.CANCELWAITING, portId: 'my_port' }),
+					})
+				)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					2,
+					expect.objectContaining({
+						command: expect.objectContaining({ type: QuantelCommandType.SETUPPORT, portId: 'my_port', channel: 1 }),
+					})
+				)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					3,
+					expect.objectContaining({
+						command: expect.objectContaining({ type: QuantelCommandType.CLEARCLIP, portId: 'my_port' }),
+					})
+				)
+
+				expect(onRequest).toHaveBeenCalledWith('post', 'http://localhost:3000/connect/myISA%3A8000')
+				expect(onRequest).toHaveBeenCalledWith('get', 'http://localhost:3000/default/server')
+				expect(onRequest).toHaveBeenCalledWith('get', 'http://localhost:3000/default/server/1100/port/my_port')
+				expect(onRequest).toHaveBeenCalledWith(
+					'put',
+					'http://localhost:3000/default/server/1100/port/my_port/channel/1'
+				)
+				expect(onRequest).toHaveBeenCalledWith('post', 'http://localhost:3000/default/server/1100/port/my_port/reset')
+				clearMocks()
+			}
+
+			// Handle state at time 1000 (myClip0 starts to play)
+			{
+				const state = getResolvedState(resolved, now + 100)
+				await stateHandler.handleState(state, mappings)
+				// Give QuantelManager some time to process the commands
+				await sleep(200)
+
+				expect(MOCK_SEND_COMMAND).toHaveBeenCalledTimes(3)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					1,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.CANCELWAITING,
+							portId: 'my_port',
+						}),
+					})
+				)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					2,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.LOADCLIPFRAGMENTS,
+							portId: 'my_port',
+							clip: expect.objectContaining({ title: 'myClip0' }),
+						}),
+					})
+				)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					3,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.PLAYCLIP,
+							portId: 'my_port',
+							clip: expect.objectContaining({ title: 'myClip0' }),
+						}),
+					})
+				)
+				expect(onRequest).toHaveBeenCalledWith('post', expect.stringContaining('/1100/port/my_port/fragments?offset=0'))
+				// expect(onRequest).toHaveBeenCalledWith('put', expect.stringContaining('/1100/port/my_port/jump?offset='))
+				// expect(onRequest).toHaveBeenCalledWith('post', expect.stringContaining('/1100/port/my_port/trigger/JUMP'))
+				expect(onRequest).toHaveBeenCalledWith('post', expect.stringContaining('/1100/port/my_port/trigger/START'))
+				expect(onRequest).toHaveBeenCalledWith('get', expect.stringContaining('/1100/port/my_port'))
+				expect(onRequest).toHaveBeenCalledWith(
+					'post',
+					expect.stringContaining('/1100/port/my_port/trigger/STOP?offset=1999')
+				)
+
+				clearMocks()
+			}
+			// Handle state at time 2000 (myClip0 should stop (but is delayed due to outTransition))
+			{
+				const state = getResolvedState(resolved, now + 200)
+				await stateHandler.handleState(state, mappings)
+				// Give QuantelManager some time to process the commands
+				await sleep(100)
+
+				expect(MOCK_SEND_COMMAND).toHaveBeenCalledTimes(2)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					1,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.LOADCLIPFRAGMENTS,
+							portId: 'my_port',
+							clip: expect.objectContaining({ title: 'myClip0' }),
+						}),
+					})
+				)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					2,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.PAUSECLIP,
+							portId: 'my_port',
+							clip: expect.objectContaining({ title: 'myClip0' }),
+							transition: { type: QuantelTransitionType.DELAY, delay: 500 },
+						}),
+					})
+				)
+
+				// Since the pause is delayed, we should not have sent any reset or stop commands:
+
+				expect(onRequest).not.toHaveBeenCalledWith('post', expect.stringContaining('reset'))
+				expect(onRequest).not.toHaveBeenCalledWith('post', expect.stringContaining('trigger/STOP'))
+
+				clearMocks()
+			}
+			// Handle state at time 2500 (myClip1 starts playing)
+			{
+				const state = getResolvedState(resolved, now + 250)
+				await stateHandler.handleState(state, mappings)
+
+				// Wait enough time to ensure that the outTransition from previous clip would have finished (had it not been cancelled)
+				await sleep(200)
+
+				expect(MOCK_SEND_COMMAND).toHaveBeenCalledTimes(3)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					1,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.CANCELWAITING,
+							portId: 'my_port',
+						}),
+					})
+				)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					2,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.LOADCLIPFRAGMENTS,
+							portId: 'my_port',
+							clip: expect.objectContaining({ title: 'myClip1' }),
+						}),
+					})
+				)
+				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
+					3,
+					expect.objectContaining({
+						command: expect.objectContaining({
+							type: QuantelCommandType.PLAYCLIP,
+							portId: 'my_port',
+							clip: expect.objectContaining({ title: 'myClip1' }),
+						}),
+					})
+				)
+
+				// Start playing of next clip:
+				expect(onRequest).toHaveBeenCalledWith(
+					'post',
+					expect.stringContaining('/1100/port/my_port/fragments?offset=2000')
+				)
+				expect(onRequest).toHaveBeenCalledWith('put', expect.stringContaining('/1100/port/my_port/jump?offset='))
+				expect(onRequest).toHaveBeenCalledWith('post', expect.stringContaining('/1100/port/my_port/trigger/JUMP'))
+				expect(onRequest).toHaveBeenCalledWith('post', expect.stringContaining('/1100/port/my_port/trigger/START'))
+				expect(onRequest).toHaveBeenCalledWith('get', expect.stringContaining('/1100/port/my_port'))
+				expect(onRequest).toHaveBeenCalledWith(
+					'post',
+					expect.stringContaining('/1100/port/my_port/trigger/STOP?offset=3233')
+				)
+				// The first clip should NOT have stopped, as it was delayed and cancelled:
+				expect(onRequest).not.toHaveBeenCalledWith('post', expect.stringMatching(/trigger\/STOP$/))
+
+				clearMocks()
+			}
+			await dev.terminate()
+		})
+	})
 })
 
 function createTimelineState(
@@ -1323,4 +1992,8 @@ function createTimelineState(
 		layers: objs as any,
 		nextEvents: [],
 	}
+}
+
+async function sleep(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/packages/timeline-state-resolver/src/integrations/quantel/__tests__/quantel.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/quantel/__tests__/quantel.spec.ts
@@ -1483,7 +1483,7 @@ describe('Quantel Device', () => {
 			const device = await getInitialisedQuantelDevice()
 
 			// give it some time to finish the init
-			await sleep(10)
+			await sleep(100)
 
 			const stateHandler = getNewStateHandler(device)
 
@@ -1541,7 +1541,8 @@ describe('Quantel Device', () => {
 				await stateHandler.handleState(state, mappings)
 
 				// Give QuantelManager some time to process the commands
-				await sleep(10)
+				await sleep(200)
+
 				expect(MOCK_SEND_COMMAND).toHaveBeenCalledTimes(3)
 				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(
 					1,
@@ -1719,7 +1720,7 @@ describe('Quantel Device', () => {
 			const dev = await getInitialisedQuantelDevice()
 
 			// give it some time to finish the init
-			await sleep(10)
+			await sleep(100)
 
 			const now = Date.now()
 
@@ -1794,7 +1795,7 @@ describe('Quantel Device', () => {
 
 				// Give QuantelManager some time to process the commands
 
-				await sleep(100)
+				await sleep(200)
 
 				expect(MOCK_SEND_COMMAND).toHaveBeenCalledTimes(3)
 				expect(MOCK_SEND_COMMAND).toHaveBeenNthCalledWith(

--- a/packages/timeline-state-resolver/src/integrations/quantel/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/quantel/connection.ts
@@ -17,7 +17,7 @@ import {
 } from './types'
 import { WaitGroup } from '../../waitGroup'
 
-const SOFT_JUMP_WAIT_TIME = 250
+let SOFT_JUMP_WAIT_TIME = 250 // Is a constant, but can be changed during unit tests
 
 const DEFAULT_FPS = 25 // frames per second
 const JUMP_ERROR_MARGIN = 10 // frames
@@ -651,4 +651,10 @@ class Cache {
 			})
 		}, 1)
 	}
+}
+/**
+ * USED IN UNIT TESTS ONLY
+ */
+export function setSoftJumpWaitTime(time: number) {
+	SOFT_JUMP_WAIT_TIME = time
 }

--- a/packages/timeline-state-resolver/src/integrations/quantel/diff.ts
+++ b/packages/timeline-state-resolver/src/integrations/quantel/diff.ts
@@ -120,7 +120,6 @@ export function diffStates(
 		}
 	}
 
-	const maxPreliminary = allCommands.reduce((memo, curr) => Math.max(memo, curr?.preliminary || 0), 0)
 	for (const portId of portIdsToCancelWaiting.values()) {
 		// Put first, so that it'll be executed before any other
 		allCommands.unshift({
@@ -133,8 +132,6 @@ export function diffStates(
 			context: 'Clear all delayed out-transitions',
 			// This must be on a unique queueId, so that it "mimics a salvo", ie is executed first thing and not get stuck behind a delayed sequential command.
 			queueId: `reset_port_${portId}`,
-
-			preliminary: maxPreliminary, // so that it'll be executed out first
 		})
 	}
 

--- a/packages/timeline-state-resolver/src/integrations/quantel/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/quantel/index.ts
@@ -143,6 +143,8 @@ export class QuantelDevice extends Device<QuantelOptions, QuantelState, QuantelC
 				await this._quantelManager.pauseClip(command)
 			} else if (command.type === QuantelCommandType.CLEARCLIP) {
 				await this._quantelManager.clearClip(command)
+			} else if (command.type === QuantelCommandType.CANCELWAITING) {
+				this._quantelManager.clearAllWaitWithPort(command.portId)
 			} else {
 				throw new Error(`Unsupported command type "${cmdType}"`)
 			}

--- a/packages/timeline-state-resolver/src/integrations/quantel/types.ts
+++ b/packages/timeline-state-resolver/src/integrations/quantel/types.ts
@@ -53,6 +53,7 @@ export enum QuantelCommandType {
 	PAUSECLIP = 'pauseClip',
 	CLEARCLIP = 'clearClip',
 	RELEASEPORT = 'releasePort',
+	CANCELWAITING = 'cancelWaiting',
 }
 export interface QuantelCommandSetupPort extends QuantelCommandBase {
 	type: QuantelCommandType.SETUPPORT
@@ -84,6 +85,9 @@ export interface QuantelCommandClearClip extends QuantelCommandBase {
 export interface QuantelCommandReleasePort extends QuantelCommandBase {
 	type: QuantelCommandType.RELEASEPORT
 }
+export interface QuantelCommandCancelWaiting extends QuantelCommandBase {
+	type: QuantelCommandType.CANCELWAITING
+}
 
 export type QuantelCommand =
 	| QuantelCommandSetupPort
@@ -92,6 +96,7 @@ export type QuantelCommand =
 	| QuantelCommandPauseClip
 	| QuantelCommandClearClip
 	| QuantelCommandReleasePort
+	| QuantelCommandCancelWaiting
 
 /** Tracked state of an ISA-Zone-Server entity */
 export interface QuantelTrackedState {

--- a/packages/timeline-state-resolver/src/service/stateHandler.ts
+++ b/packages/timeline-state-resolver/src/service/stateHandler.ts
@@ -44,7 +44,7 @@ export class StateHandler<DeviceState, Command extends CommandWithContext<any, a
 		})
 
 		this._commandExecutor = new CommandExecutor(context.logger, this.config.executionType, async (c) =>
-			device.sendCommand(c)
+			this.device.sendCommand(c)
 		)
 
 		this.clock = setInterval(() => {


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the NRK

## Type of Contribution

This is a: Bug fix 


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

_Note: This PR replaces https://github.com/nrkno/sofie-timeline-state-resolver/pull/352_

There currently is a situation where:

1. Clip A is playing
2. Clip A is stopped, however it has an outTransition: DELAY set
  so the stop command wont be sent until a while later
3. Clip B starts playing (on same port)

The Quantel device might either
* Wait with playing B until the stop-command for A has executed.
* Start playing B, then stop it (because of the delayed stop-command)


## New Behavior
<!--
What is the new behavior?
-->

The Quantel device has now added a CLEARWAITING command that is executed first, to ensure that any lingering delayed command is cancelled, whatever it was going to do will be replaced by the new command.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

* Test playout of Quantel clips thoroughly.


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
