### PR TITLE
feat!: remove unused makeReady and standDown flow

### DIFF
--- a/packages/timeline-state-resolver-api/src/device.ts
+++ b/packages/timeline-state-resolver-api/src/device.ts
@@ -54,11 +54,6 @@ export interface Device<
 	 */
 	terminate(): Promise<void>
 
-	/** @deprecated */
-	makeReady?: (_okToDestroyStuff?: boolean) => Promise<void>
-	/** @deprecated */
-	standDown?: () => Promise<void>
-
 	get connected(): boolean
 	getStatus(): Omit<DeviceStatus, 'active'>
 

--- a/packages/timeline-state-resolver-types/src/generated/tcpSend.ts
+++ b/packages/timeline-state-resolver-types/src/generated/tcpSend.ts
@@ -21,19 +21,6 @@ export interface TcpSendOptions {
 		| 'latin1'
 		| 'binary'
 		| 'hex'
-	/**
-	 * Whether a makeReady should be treated as a reset of the device. It should be assumed clean, with the queue discarded, and state reapplied from empty
-	 */
-	makeReadyDoesReset?: boolean
-	makeReadyCommands?: TcpSendCommandContent[]
-}
-export interface TcpSendCommandContent {
-	message: string
-	temporalPriority?: number
-	/**
-	 * Commands in the same queue will be sent in order (will wait for the previous to finish before sending next
-	 */
-	queueId?: string
 }
 
 export type SomeMappingTcpSend = Record<string, never>

--- a/packages/timeline-state-resolver-types/src/generated/vizMSE.ts
+++ b/packages/timeline-state-resolver-types/src/generated/vizMSE.ts
@@ -53,10 +53,6 @@ export interface VizMSEOptions {
 	 */
 	clearAllTemplateName?: string
 	/**
-	 * Whether to trigger a clear all templates upon makeReady
-	 */
-	clearAllOnMakeReady?: boolean
-	/**
 	 * If true, the rundown won't be deactivated on standdown
 	 */
 	dontDeactivateOnStandDown?: boolean

--- a/packages/timeline-state-resolver-types/src/integrations/tcpSend.ts
+++ b/packages/timeline-state-resolver-types/src/integrations/tcpSend.ts
@@ -1,7 +1,16 @@
-import { DeviceType, TcpSendCommandContent } from '..'
+import { DeviceType } from '..'
 
 export type TimelineContentTCPSendAny = TimelineContentTCPRequest
 export interface TimelineContentTCPSendBase {
 	deviceType: DeviceType.TCPSEND
 }
 export type TimelineContentTCPRequest = TimelineContentTCPSendBase & TcpSendCommandContent
+
+export interface TcpSendCommandContent {
+	message: string
+	temporalPriority?: number
+	/**
+	 * Commands in the same queue will be sent in order (will wait for the previous to finish before sending next
+	 */
+	queueId?: string
+}

--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -108,7 +108,6 @@
 		"osc": "^2.4.5",
 		"p-all": "^3.0.0",
 		"p-queue": "^6.6.2",
-		"p-timeout": "^3.2.0",
 		"simple-oauth2": "^5.1.0",
 		"sprintf-js": "^1.1.3",
 		"superfly-timeline": "^9.1.2",

--- a/packages/timeline-state-resolver/src/__tests__/conductor.spec.ts
+++ b/packages/timeline-state-resolver/src/__tests__/conductor.spec.ts
@@ -394,48 +394,6 @@ describe('Conductor', () => {
 		}
 	})
 
-	test('devicesMakeReady', async () => {
-		const conductor = new Conductor({
-			multiThreadedResolver: false,
-			getCurrentTime: mockTime.getCurrentTime,
-		})
-
-		try {
-			await conductor.init()
-			await addConnections(conductor.connectionManager, {
-				device0: {
-					type: DeviceType.ABSTRACT,
-					options: {},
-				},
-				device1: {
-					type: DeviceType.ABSTRACT,
-					options: {},
-				},
-			})
-
-			const device0 = await getMockDeviceWrapper(conductor, 'device0')
-			device0.makeReady.mockImplementationOnce(async () => {
-				// Allow it
-			})
-			const device1 = await getMockDeviceWrapper(conductor, 'device1')
-			device1.makeReady.mockImplementationOnce(async () => {
-				// Allow it
-			})
-
-			expect(device0.makeReady).toHaveBeenCalledTimes(0)
-			expect(device1.makeReady).toHaveBeenCalledTimes(0)
-
-			await mockTime.advanceTimeTicks(10) // to allow casparcg to fake "connect"
-
-			await conductor.devicesMakeReady(true)
-
-			expect(device0.makeReady).toHaveBeenCalledTimes(1)
-			expect(device1.makeReady).toHaveBeenCalledTimes(1)
-		} finally {
-			await conductor.destroy()
-		}
-	})
-
 	test('Construction of multithreaded device', async () => {
 		const myLayerMapping0: Mapping<SomeMappingAbstract> = {
 			device: DeviceType.ABSTRACT,

--- a/packages/timeline-state-resolver/src/__tests__/mockDeviceInstanceWrapper.ts
+++ b/packages/timeline-state-resolver/src/__tests__/mockDeviceInstanceWrapper.ts
@@ -72,12 +72,6 @@ export class MockDeviceInstanceWrapper
 			throw new Error('Method not implemented.')
 		}
 	)
-	makeReady = jest.fn(async (_okToDestroyStuff?: boolean | undefined): Promise<void> => {
-		throw new Error('Method not implemented.')
-	})
-	standDown = jest.fn(async (): Promise<void> => {
-		throw new Error('Method not implemented.')
-	})
 
 	/** @deprecated - just here for API compatiblity with the old class */
 	prepareForHandleState(): void {

--- a/packages/timeline-state-resolver/src/devices/device.ts
+++ b/packages/timeline-state-resolver/src/devices/device.ts
@@ -86,8 +86,6 @@ export interface IDevice<TOptions extends DeviceOptionsBase<any>> {
 	canConnect: boolean
 	connected: boolean
 
-	makeReady: (_okToDestroyStuff?: boolean, activeRundownId?: string) => Promise<void>
-	standDown: (_okToDestroyStuff?: boolean) => Promise<void>
 	getStatus: () => DeviceStatus
 
 	deviceId: string
@@ -193,25 +191,6 @@ export abstract class Device<
 	abstract get canConnect(): boolean
 	abstract get connected(): boolean
 
-	/**
-	 * The makeReady method could be triggered at a time before broadcast
-	 * Whenever we know that the user want's to make sure things are ready for broadcast
-	 * The exact implementation differ between different devices
-	 * @param okToDestroyStuff If true, the device may do things that might affect the output (temporarily)
-	 */
-	async makeReady(_okToDestroyStuff?: boolean, _activeRundownId?: string): Promise<void> {
-		// This method should be overwritten by child
-		return Promise.resolve()
-	}
-	/**
-	 * The standDown event could be triggered at a time after broadcast
-	 * The exact implementation differ between different devices
-	 * @param okToDestroyStuff If true, the device may do things that might affect the output (temporarily)
-	 */
-	async standDown(_okToDestroyStuff?: boolean): Promise<void> {
-		// This method should be overwritten by child
-		return Promise.resolve()
-	}
 	abstract getStatus(): DeviceStatus
 
 	setDebugLogging(debug: boolean) {

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -120,9 +120,6 @@ export class CasparCGDevice extends DeviceWithState<State, CasparCGDeviceTypes, 
 		let firstConnect = true
 
 		this._ccg.on('connect', () => {
-			this.makeReady(false) // always make sure timecode is correct, setting it can never do bad
-				.catch((e) => this.emit('error', 'casparCG.makeReady', e))
-
 			Promise.resolve()
 				.then(async () => {
 					// a "virgin server" was just restarted (so it is cleared & black).
@@ -610,19 +607,6 @@ export class CasparCGDevice extends DeviceWithState<State, CasparCGDeviceTypes, 
 		})
 
 		return caspar
-	}
-
-	/**
-	 * Prepares the physical device for playout. If amcp scheduling is used this
-	 * tries to sync the timecode. If {@code okToDestroyStuff === true} this clears
-	 * all channels and resets our states.
-	 * @param okToDestroyStuff Whether it is OK to restart the device
-	 */
-	async makeReady(okToDestroyStuff?: boolean): Promise<void> {
-		// reset our own state(s):
-		if (okToDestroyStuff) {
-			await this.clearAllChannels()
-		}
 	}
 
 	private async clearAllChannels(): Promise<ActionExecutionResult> {

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -177,9 +177,6 @@ export class SisyfosMessageDevice extends DeviceWithState<
 			active: this.isActive,
 		}
 	}
-	async makeReady(okToDestroyStuff?: boolean): Promise<void> {
-		if (okToDestroyStuff) return this._makeReadyInner(okToDestroyStuff)
-	}
 
 	private async _makeReadyInner(resync?: boolean): Promise<void> {
 		if (resync) {

--- a/packages/timeline-state-resolver/src/integrations/tcpSend/$schemas/options.json
+++ b/packages/timeline-state-resolver/src/integrations/tcpSend/$schemas/options.json
@@ -16,40 +16,6 @@
 			"ui:title": "Buffer Encoding",
 			"enum": ["ascii", "utf8", "utf-8", "utf16le", "ucs2", "ucs-2", "base64", "base64url", "latin1", "binary", "hex"],
 			"default": "utf8"
-		},
-		"makeReadyDoesReset": {
-			"type": "boolean",
-			"ui:title": "",
-			"description": "Whether a makeReady should be treated as a reset of the device. It should be assumed clean, with the queue discarded, and state reapplied from empty",
-			"default": false
-		},
-		"makeReadyCommands": {
-			"type": "array",
-			"ui:title": "Make Ready Commands",
-			"items": {
-				"type": "object",
-				"title": "TcpSendCommandContent",
-				"todo": "should this be pulled in from elsewhere? its a timeline object type too",
-				"properties": {
-					"message": {
-						"type": "string",
-						"ui:title": "Message",
-						"default": ""
-					},
-					"temporalPriority": {
-						"type": "integer",
-						"ui:title": "Temporal Priority",
-						"default": 0
-					},
-					"queueId": {
-						"type": "string",
-						"description": "Commands in the same queue will be sent in order (will wait for the previous to finish before sending next",
-						"ui:title": "Send Queue Id"
-					}
-				},
-				"required": ["message"],
-				"additionalProperties": false
-			}
 		}
 	},
 	"required": ["host", "port"],

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/$schemas/options.json
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/$schemas/options.json
@@ -61,11 +61,6 @@
 			"ui:title": "Clear-All template name",
 			"description": "It is a common practice to have an element which only purpose is to \"clear all graphics\" on the vizEngine.\nTo use this in TSR, set a reference to that here"
 		},
-		"clearAllOnMakeReady": {
-			"type": "boolean",
-			"ui:title": "Clear-All on make-ready (activate rundown)",
-			"description": "Whether to trigger a clear all templates upon makeReady"
-		},
 		"dontDeactivateOnStandDown": {
 			"type": "boolean",
 			"ui:title": "Don't deactivate on stand-down (deactivate rundown)",

--- a/packages/timeline-state-resolver/src/integrations/vmix/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/index.ts
@@ -280,12 +280,6 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, VmixDeviceTyp
 		}
 	}
 
-	async makeReady(okToDestroyStuff?: boolean): Promise<void> {
-		if (okToDestroyStuff) {
-			// do something?
-		}
-	}
-
 	readonly actions: VmixActionMethods = {
 		[VmixActions.LastPreset]: async () => this._lastPreset(),
 		[VmixActions.OpenPreset]: async (payload) => this._openPreset(payload),

--- a/packages/timeline-state-resolver/src/service/DeviceInstance.ts
+++ b/packages/timeline-state-resolver/src/service/DeviceInstance.ts
@@ -203,13 +203,6 @@ export class DeviceInstanceWrapper extends EventEmitter<DeviceInstanceEvents> {
 		return action(payload)
 	}
 
-	async makeReady(okToDestroyStuff?: boolean): Promise<void> {
-		return this._device.makeReady?.(okToDestroyStuff)
-	}
-	async standDown(): Promise<void> {
-		return this._device.standDown?.()
-	}
-
 	/** @deprecated - just here for API compatiblity with the old class */
 	prepareForHandleState() {
 		//

--- a/packages/timeline-state-resolver/src/service/device.ts
+++ b/packages/timeline-state-resolver/src/service/device.ts
@@ -42,15 +42,6 @@ export abstract class Device<
 	 */
 	abstract terminate(): Promise<void>
 
-	/** @deprecated */
-	async makeReady(_okToDestroyStuff?: boolean): Promise<void> {
-		// Do nothing by default
-	}
-	/** @deprecated */
-	async standDown(): Promise<void> {
-		// Do nothing by default
-	}
-
 	abstract get connected(): boolean
 	abstract getStatus(): Omit<DeviceStatus, 'active'>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11356,7 +11356,6 @@ asn1@evs-broadcast/node-asn1:
     osc: ^2.4.5
     p-all: ^3.0.0
     p-queue: ^6.6.2
-    p-timeout: ^3.2.0
     simple-oauth2: ^5.1.0
     sprintf-js: ^1.1.3
     superfly-timeline: ^9.1.2


### PR DESCRIPTION


## About the Contributor

This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Feature / Code improvement 



## New Behavior

Since at least release50 (2 years ago), these methods have been marked as deprecated and have been unused by sofie-core since soon after that.

As release53 already has some breaking changes, now feels like a good time to do the cleanup and remove this dead code.

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
