### PR TITLE
Fix: Handle weird Pharos response

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/pharos/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/pharos/connection.ts
@@ -600,6 +600,18 @@ export class Pharos extends EventEmitter {
 					}
 				})
 				.catch((error) => {
+					if (error instanceof got.RequestError) {
+						// There is a weird case where Pharos replies with a body that doesn't match the content-length.
+						// Which causes node.js http.request to throw an error:
+						// RequestError: Parse Error: Expected HTTP/, RTSP/ or ICE/
+						const statusCode = error.response?.statusCode
+						if (typeof statusCode === 'number' && statusCode >= 200 && statusCode <= 299) {
+							// The request actually succeeded
+							resolve(undefined)
+							return
+						}
+					}
+
 					error.stack += `\nOriginal stack: ${orgError.stack}`
 
 					const emitError = new Error(`Error ${method} ${url} (${JSON.stringify(data)}): ${error}`)


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Bug fix

## Current Behavior

<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

When the Pharos integration sends a POST request, the Pharos responds with a bad HTTP response, which causes a `RequestError: Parse Error: Expected HTTP/, RTSP/ or ICE/`-error.

_Speculation/unverified: This response is handled differently in different Node.js versions, that's why we haven't seen this before._

## New Behavior

<!--
What is the new behavior?
-->

A special error handling case, to handle the specific HTTP response error in the Pharos integration.

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

* Test the Pharos device

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
