### PR TITLE
Use frame rate reported by CasparCG if nothing else is configured

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -174,16 +174,18 @@ export class CasparCGDevice extends DeviceWithState<State, CasparCGDeviceTypes, 
 						firstConnect = false
 						this.clearStates()
 						this.emit('resyncStates')
+						// Clear all state on resync
+						this._currentState = { channels: {} }
 					}
 
-					// Populate channel info (including fps) after resync decision
-					this._currentState = { channels: {} }
+					// Populate/update channel info (including fps), preserving existing layers
 					for (const obj of channelInfo) {
+						const existingChannel = this._currentState.channels[obj.channel]
 						this._currentState.channels[obj.channel] = {
 							channelNo: obj.channel,
 							videoMode: this.getVideMode(obj),
 							fps: obj.frameRate,
-							layers: {},
+							layers: existingChannel?.layers || {},
 						}
 					}
 				})

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -515,7 +515,8 @@ export class CasparCGDevice extends DeviceWithState<State, CasparCGDeviceTypes, 
 				// create a channel in state if necessary, or reuse existing channel
 				const channel = caspar.channels[mapping.options.channel] || { channelNo: mapping.options.channel, layers: {} }
 				channel.channelNo = mapping.options.channel
-				channel.fps = this.initOptions ? this.initOptions.fps || 25 : 25
+				// Use configured fps if set (for override), otherwise auto-detect from CasparCG INFO, then default
+				channel.fps = this.initOptions?.fps || this._currentState.channels[mapping.options.channel]?.fps || 25
 				caspar.channels[channel.channelNo] = channel
 
 				let foregroundObj: ResolvedTimelineObjectInstanceExtended | undefined = timelineState.layers[layerName]


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

## Type of Contribution

This is a Bug fix / Feature

## Current Behavior

The framerate is read from CasparCG with the INFO command, but it is ignored. It uses a user configured value or a default of 25. This breaks timing in e.g. 50i modes, meaning that you jump to a point twice as far in a video than you should. It probably breaks 30 and 60fps to, but I we didn't test that.

## New Behavior

Use the value from the INFO command if config is unset. Only default to 25 if that doesn't work.

## Testing Instructions

@Saftret Can you review this?

While working in a 50i setup, leave the configured value in `settings -> studio -> playout devices -> CasparCG -> frame rate` blank. Then jump to a place in a clip (how?). It should take you to the right place. The previous version would take you to a point double what you requested.

## Other Information

This was discussed and coded at the SuperFlyTV dev meet on 2026/01/22.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Use detected frame rate as default if not configured

### Problem
The CasparCG integration was ignoring the frame rate reported by CasparCG's INFO command and instead relying on a user-configured value or defaulting to 25 fps. This caused incorrect timing behavior—notably, in 50i setups, jumps landed at twice the requested position, and the issue potentially affects 30/60 fps configurations as well.

### Solution
Modified the CasparCG integration to prioritize the frame rate detected from CasparCG's INFO command when the user has not explicitly configured a frame rate. The fallback hierarchy is now:
1. User-configured frame rate (if set)
2. Frame rate detected from CasparCG INFO response
3. Default to 25 fps (only if detection is unavailable or invalid)

### Technical Changes
- Refactored channel initialization and resync logic to return a structured object `{ doResync: boolean, channelInfo: InfoEntry[] }` instead of a plain boolean, enabling more flexible channel metadata handling
- Deferred per-channel INFO population from the virgin connection phase, constructing channel info asynchronously via a promise chain
- Reworked the resync decision flow: when any channel contains layers, returns `doResync: false`; otherwise `doResync: true`
- Updated error handling to return structured resync signals with empty channel info
- Enhanced the post-connection handler to apply resync state and populate `_currentState` from the retrieved channel info
- Modified FPS resolution logic: uses configured `initOptions.fps` if available, else falls back to detected FPS from `_currentState` for the channel, or defaults to 25
- Ensured channel metadata (FPS, video mode) is properly reconstructed after clearing all channels

### Testing
Testing instructions provided: In a 50i setup, leave the CasparCG frame rate configuration blank and verify that jumps to clip positions land at the correct location (previously landed at double the requested position).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->