### PR TITLE
Fix gh actions warning

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -188,7 +188,7 @@ jobs:
         env:
           CI: true
       - name: Generate docs
-        if: ${{ steps.do-publish.outputs.tag }} == 'latest'
+        if: ${{ steps.do-publish.outputs.tag == 'latest' }}
         run: |
           yarn docs
       - name: Publish docs


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the myself

## Type of Contribution

This is a Bug fix (CI)

## Current Behavior

The generate docs part of CI is only intended to run when the build is tagged with latest:

```yaml
      - name: Generate docs
        if: ${{ steps.do-publish.outputs.tag }} == 'latest'
```

This doesn't work. Yaml converts it to a string like "foo == 'latest'" which evaluates truthy.

This means we are generating docs when we don't want to.

## New Behavior

Move the `==` inside the `${{ }}` and it should evaluate to true or false as expected.

```yaml
 ${{ steps.do-publish.outputs.tag == 'latest' }}
```

## Testing Instructions

Can't really be tested except by putting it live and checking CI carefully.

## Other Information

Prompted by this warning:

<img width="1712" height="152" alt="Screenshot 2026-01-28 at 11 51 12" src="https://github.com/user-attachments/assets/f5b5c291-4cc3-4361-92e6-6ab867934e1f" />

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
