### PR TITLE
fix: update minimum nodejs to 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@sofie-automation/code-standard-preset": "~2.5.2",
     "@types/debug": "^4.1.12",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20.19.28",
+    "@types/node": "^22.19.11",
     "@types/semver": "^7.7.1",
     "@types/sprintf-js": "^1.1.4",
     "@types/underscore": "^1.13.0",

--- a/packages/quick-tsr/package.json
+++ b/packages/quick-tsr/package.json
@@ -41,7 +41,7 @@
 		]
 	},
 	"engines": {
-		"node": ">= 20.5"
+		"node": ">= 22.18"
 	},
 	"keywords": [
 		"broadcast",

--- a/packages/timeline-state-resolver-api/package.json
+++ b/packages/timeline-state-resolver-api/package.json
@@ -54,7 +54,7 @@
 		"license-validate": "run -T  sofie-licensecheck"
 	},
 	"engines": {
-		"node": ">= 20.5"
+		"node": ">= 22.18"
 	},
 	"files": [
 		"/dist",

--- a/packages/timeline-state-resolver-tools/package.json
+++ b/packages/timeline-state-resolver-tools/package.json
@@ -55,7 +55,7 @@
 		"tsr-schema-types": "bin/schema-types.mjs"
 	},
 	"engines": {
-		"node": ">= 20.5"
+		"node": ">= 22.18"
 	},
 	"files": [
 		"/lib",

--- a/packages/timeline-state-resolver-types/package.json
+++ b/packages/timeline-state-resolver-types/package.json
@@ -58,7 +58,7 @@
 		"license-validate": "run -T  sofie-licensecheck"
 	},
 	"engines": {
-		"node": ">= 20.5"
+		"node": ">= 22.18"
 	},
 	"files": [
 		"/dist",

--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -68,7 +68,7 @@
 		"schema:types": "tsr-schema-types ./src/\\$schemas/generated ../timeline-state-resolver-types/src/generated --isMainRepository"
 	},
 	"engines": {
-		"node": ">= 20.5"
+		"node": ">= 22.18"
 	},
 	"files": [
 		"/dist",

--- a/packages/timeline-state-resolver/tsconfig.build.json
+++ b/packages/timeline-state-resolver/tsconfig.build.json
@@ -12,6 +12,7 @@
 		},
 		"types": ["node"],
 		"composite": true,
+		"target": "es2022",
 
 		"moduleResolution": "node16",
 		"esModuleInterop": true,
@@ -21,7 +22,7 @@
 		"resolveJsonModule": true,
 
 		// include dom types for obs
-		"lib": ["dom", "es2020"]
+		"lib": ["dom", "es2022"]
 	},
 	"references": [
 		{ "path": "../timeline-state-resolver-types/tsconfig.build.json" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,12 +2857,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^20.19.28":
-  version: 20.19.28
-  resolution: "@types/node@npm:20.19.28"
+"@types/node@npm:*, @types/node@npm:^22.19.11":
+  version: 22.19.11
+  resolution: "@types/node@npm:22.19.11"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10c0/aaa2de8570bfafdb9c160c1dbe3ecd7d9b2ccdc496ab6b0f24ccd5023aabe6f8c7fd02d7090185c2912052174f7cffef4ace80edd7d2a433200429c7a0a4869d
+  checksum: 10c0/4b274acf27ec31aa83b50ef22088f83c783e6bcd7dcb40b4834f64f44868b6bf68725214220f15a0c776928f7c0f7f26f03c05cd5868f0526340af3f4af4b58b
   languageName: node
   linkType: hard
 
@@ -12253,7 +12253,7 @@ asn1@evs-broadcast/node-asn1:
     "@sofie-automation/code-standard-preset": "npm:~2.5.2"
     "@types/debug": "npm:^4.1.12"
     "@types/jest": "npm:^30.0.0"
-    "@types/node": "npm:^20.19.28"
+    "@types/node": "npm:^22.19.11"
     "@types/semver": "npm:^7.7.1"
     "@types/sprintf-js": "npm:^1.1.4"
     "@types/underscore": "npm:^1.13.0"


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of Superfly

## Type of Contribution

This is a: Bug fix / Feature / Code improvement 

## New Behavior

As discussed and approved by the TSC

The minimum nodejs set for this release is currently >=20.

By the time this gets released as stable, it will be less than 2 months until 20 stops getting security updates.  
By setting the minimum to 22 now (as this is already a semver major), we will likely delay the need to do another semver major to update node version again for another year.

And this means that in any libraries we maintain for use here, we can also set their minimum to 22 (they are mostly on 14+ currently, as that is what the previous release of TSR requires, which has been holding back versions of many dependencies and tools)

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
