### PR TITLE
fix: rework generated types to minimise variation in type union

### DIFF
--- a/packages/timeline-state-resolver-tools/bin/schema-types.mjs
+++ b/packages/timeline-state-resolver-tools/bin/schema-types.mjs
@@ -227,7 +227,7 @@ for (const dir of dirs) {
 
 	const dirId = capitalise(dir)
 
-	let output = ''
+	let output = "import type { DeviceType } from './device-options.js'\n"
 
 	// compile options from file
 	try {
@@ -401,14 +401,6 @@ ${actionDefinitions
 			}"\n` + output
 	}
 
-	output += `
-export interface ${dirId}DeviceTypes {
-	Options: ${dirId}Options
-	Mappings: SomeMapping${dirId}
-	Actions: ${actionDefinitions.length > 0 ? `${dirId}ActionMethods` : 'null'}
-}
-`
-
 	let deviceTypeId = toConstantCase(dir)
 	// Special case handling for some devices, for backwards compatibility
 	if (
@@ -422,10 +414,17 @@ export interface ${dirId}DeviceTypes {
 	}
 	deviceTypeEnum.push(deviceTypeId)
 
+	output += `
+export interface ${dirId}DeviceTypes {
+	Type: DeviceType.${deviceTypeId},
+	Options: ${dirId}Options
+	Mappings: SomeMapping${dirId}
+	Actions: ${actionDefinitions.length > 0 ? `${dirId}ActionMethods` : 'null'}
+}
+`
+
 	deviceOptionsFile += `import type { ${dirId}Options } from './${dir}'
-export interface DeviceOptions${dirId} extends DeviceOptionsBase<${dirId}Options> {
-	type: DeviceType.${deviceTypeId}
-}\n\n`
+export type DeviceOptions${dirId} = DeviceOptionsBase<DeviceType.${deviceTypeId}, ${dirId}Options>\n\n`
 	deviceOptionsTypes.push(`DeviceOptions${dirId}`)
 
 	manifestFileSubdevices += `\t\t[DeviceType.${deviceTypeId}]: {

--- a/packages/timeline-state-resolver-types/src/device.ts
+++ b/packages/timeline-state-resolver-types/src/device.ts
@@ -15,11 +15,11 @@ export interface DeviceStatus {
 	active: boolean
 }
 
-export interface DeviceOptionsBase<T> extends SlowReportOptions, DeviceCommonOptions {
-	type: DeviceType
+export interface DeviceOptionsBase<TType extends DeviceType, TOptions> extends SlowReportOptions, DeviceCommonOptions {
+	type: TType
 	isMultiThreaded?: boolean
 	reportAllCommands?: boolean
-	options?: T
+	options?: TOptions
 }
 
 export interface SlowReportOptions {

--- a/packages/timeline-state-resolver-types/src/generated/abstract.ts
+++ b/packages/timeline-state-resolver-types/src/generated/abstract.ts
@@ -5,6 +5,7 @@
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
 import type { ActionExecutionResult } from "../actions"
+import type { DeviceType } from './device-options.js'
 
 export interface AbstractOptions {}
 
@@ -18,6 +19,7 @@ export interface AbstractActionMethods {
 }
 
 export interface AbstractDeviceTypes {
+	Type: DeviceType.ABSTRACT,
 	Options: AbstractOptions
 	Mappings: SomeMappingAbstract
 	Actions: AbstractActionMethods

--- a/packages/timeline-state-resolver-types/src/generated/atem.ts
+++ b/packages/timeline-state-resolver-types/src/generated/atem.ts
@@ -5,6 +5,7 @@
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
 import type { ActionExecutionResult } from "../actions"
+import type { DeviceType } from './device-options.js'
 
 export interface AtemOptions {
 	host: string
@@ -113,6 +114,7 @@ export interface AtemActionMethods {
 }
 
 export interface AtemDeviceTypes {
+	Type: DeviceType.ATEM,
 	Options: AtemOptions
 	Mappings: SomeMappingAtem
 	Actions: AtemActionMethods

--- a/packages/timeline-state-resolver-types/src/generated/casparCG.ts
+++ b/packages/timeline-state-resolver-types/src/generated/casparCG.ts
@@ -5,6 +5,7 @@
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
 import type { ActionExecutionResult } from "../actions"
+import type { DeviceType } from './device-options.js'
 
 export interface CasparCGOptions {
 	/**
@@ -66,6 +67,7 @@ export interface CasparCGActionMethods {
 }
 
 export interface CasparCGDeviceTypes {
+	Type: DeviceType.CASPARCG,
 	Options: CasparCGOptions
 	Mappings: SomeMappingCasparCG
 	Actions: CasparCGActionMethods

--- a/packages/timeline-state-resolver-types/src/generated/device-options.ts
+++ b/packages/timeline-state-resolver-types/src/generated/device-options.ts
@@ -7,129 +7,79 @@
 
 import type { DeviceOptionsBase } from '../device'
 import type { AbstractOptions } from './abstract'
-export interface DeviceOptionsAbstract extends DeviceOptionsBase<AbstractOptions> {
-	type: DeviceType.ABSTRACT
-}
+export type DeviceOptionsAbstract = DeviceOptionsBase<DeviceType.ABSTRACT, AbstractOptions>
 
 import type { AtemOptions } from './atem'
-export interface DeviceOptionsAtem extends DeviceOptionsBase<AtemOptions> {
-	type: DeviceType.ATEM
-}
+export type DeviceOptionsAtem = DeviceOptionsBase<DeviceType.ATEM, AtemOptions>
 
 import type { CasparCGOptions } from './casparCG'
-export interface DeviceOptionsCasparCG extends DeviceOptionsBase<CasparCGOptions> {
-	type: DeviceType.CASPARCG
-}
+export type DeviceOptionsCasparCG = DeviceOptionsBase<DeviceType.CASPARCG, CasparCGOptions>
 
 import type { HttpSendOptions } from './httpSend'
-export interface DeviceOptionsHttpSend extends DeviceOptionsBase<HttpSendOptions> {
-	type: DeviceType.HTTPSEND
-}
+export type DeviceOptionsHttpSend = DeviceOptionsBase<DeviceType.HTTPSEND, HttpSendOptions>
 
 import type { HttpWatcherOptions } from './httpWatcher'
-export interface DeviceOptionsHttpWatcher extends DeviceOptionsBase<HttpWatcherOptions> {
-	type: DeviceType.HTTPWATCHER
-}
+export type DeviceOptionsHttpWatcher = DeviceOptionsBase<DeviceType.HTTPWATCHER, HttpWatcherOptions>
 
 import type { HyperdeckOptions } from './hyperdeck'
-export interface DeviceOptionsHyperdeck extends DeviceOptionsBase<HyperdeckOptions> {
-	type: DeviceType.HYPERDECK
-}
+export type DeviceOptionsHyperdeck = DeviceOptionsBase<DeviceType.HYPERDECK, HyperdeckOptions>
 
 import type { KairosOptions } from './kairos'
-export interface DeviceOptionsKairos extends DeviceOptionsBase<KairosOptions> {
-	type: DeviceType.KAIROS
-}
+export type DeviceOptionsKairos = DeviceOptionsBase<DeviceType.KAIROS, KairosOptions>
 
 import type { LawoOptions } from './lawo'
-export interface DeviceOptionsLawo extends DeviceOptionsBase<LawoOptions> {
-	type: DeviceType.LAWO
-}
+export type DeviceOptionsLawo = DeviceOptionsBase<DeviceType.LAWO, LawoOptions>
 
 import type { MultiOscOptions } from './multiOsc'
-export interface DeviceOptionsMultiOsc extends DeviceOptionsBase<MultiOscOptions> {
-	type: DeviceType.MULTI_OSC
-}
+export type DeviceOptionsMultiOsc = DeviceOptionsBase<DeviceType.MULTI_OSC, MultiOscOptions>
 
 import type { ObsOptions } from './obs'
-export interface DeviceOptionsObs extends DeviceOptionsBase<ObsOptions> {
-	type: DeviceType.OBS
-}
+export type DeviceOptionsObs = DeviceOptionsBase<DeviceType.OBS, ObsOptions>
 
 import type { OscOptions } from './osc'
-export interface DeviceOptionsOsc extends DeviceOptionsBase<OscOptions> {
-	type: DeviceType.OSC
-}
+export type DeviceOptionsOsc = DeviceOptionsBase<DeviceType.OSC, OscOptions>
 
 import type { PanasonicPTZOptions } from './panasonicPTZ'
-export interface DeviceOptionsPanasonicPTZ extends DeviceOptionsBase<PanasonicPTZOptions> {
-	type: DeviceType.PANASONIC_PTZ
-}
+export type DeviceOptionsPanasonicPTZ = DeviceOptionsBase<DeviceType.PANASONIC_PTZ, PanasonicPTZOptions>
 
 import type { PharosOptions } from './pharos'
-export interface DeviceOptionsPharos extends DeviceOptionsBase<PharosOptions> {
-	type: DeviceType.PHAROS
-}
+export type DeviceOptionsPharos = DeviceOptionsBase<DeviceType.PHAROS, PharosOptions>
 
 import type { QuantelOptions } from './quantel'
-export interface DeviceOptionsQuantel extends DeviceOptionsBase<QuantelOptions> {
-	type: DeviceType.QUANTEL
-}
+export type DeviceOptionsQuantel = DeviceOptionsBase<DeviceType.QUANTEL, QuantelOptions>
 
 import type { ShotokuOptions } from './shotoku'
-export interface DeviceOptionsShotoku extends DeviceOptionsBase<ShotokuOptions> {
-	type: DeviceType.SHOTOKU
-}
+export type DeviceOptionsShotoku = DeviceOptionsBase<DeviceType.SHOTOKU, ShotokuOptions>
 
 import type { SingularLiveOptions } from './singularLive'
-export interface DeviceOptionsSingularLive extends DeviceOptionsBase<SingularLiveOptions> {
-	type: DeviceType.SINGULAR_LIVE
-}
+export type DeviceOptionsSingularLive = DeviceOptionsBase<DeviceType.SINGULAR_LIVE, SingularLiveOptions>
 
 import type { SisyfosOptions } from './sisyfos'
-export interface DeviceOptionsSisyfos extends DeviceOptionsBase<SisyfosOptions> {
-	type: DeviceType.SISYFOS
-}
+export type DeviceOptionsSisyfos = DeviceOptionsBase<DeviceType.SISYFOS, SisyfosOptions>
 
 import type { SofieChefOptions } from './sofieChef'
-export interface DeviceOptionsSofieChef extends DeviceOptionsBase<SofieChefOptions> {
-	type: DeviceType.SOFIE_CHEF
-}
+export type DeviceOptionsSofieChef = DeviceOptionsBase<DeviceType.SOFIE_CHEF, SofieChefOptions>
 
 import type { TcpSendOptions } from './tcpSend'
-export interface DeviceOptionsTcpSend extends DeviceOptionsBase<TcpSendOptions> {
-	type: DeviceType.TCPSEND
-}
+export type DeviceOptionsTcpSend = DeviceOptionsBase<DeviceType.TCPSEND, TcpSendOptions>
 
 import type { TelemetricsOptions } from './telemetrics'
-export interface DeviceOptionsTelemetrics extends DeviceOptionsBase<TelemetricsOptions> {
-	type: DeviceType.TELEMETRICS
-}
+export type DeviceOptionsTelemetrics = DeviceOptionsBase<DeviceType.TELEMETRICS, TelemetricsOptions>
 
 import type { TricasterOptions } from './tricaster'
-export interface DeviceOptionsTricaster extends DeviceOptionsBase<TricasterOptions> {
-	type: DeviceType.TRICASTER
-}
+export type DeviceOptionsTricaster = DeviceOptionsBase<DeviceType.TRICASTER, TricasterOptions>
 
 import type { ViscaOverIPOptions } from './viscaOverIP'
-export interface DeviceOptionsViscaOverIP extends DeviceOptionsBase<ViscaOverIPOptions> {
-	type: DeviceType.VISCA_OVER_IP
-}
+export type DeviceOptionsViscaOverIP = DeviceOptionsBase<DeviceType.VISCA_OVER_IP, ViscaOverIPOptions>
 
 import type { VizMSEOptions } from './vizMSE'
-export interface DeviceOptionsVizMSE extends DeviceOptionsBase<VizMSEOptions> {
-	type: DeviceType.VIZMSE
-}
+export type DeviceOptionsVizMSE = DeviceOptionsBase<DeviceType.VIZMSE, VizMSEOptions>
 
 import type { VmixOptions } from './vmix'
-export interface DeviceOptionsVmix extends DeviceOptionsBase<VmixOptions> {
-	type: DeviceType.VMIX
-}
+export type DeviceOptionsVmix = DeviceOptionsBase<DeviceType.VMIX, VmixOptions>
 
 import type { WebsocketClientOptions } from './websocketClient'
-export interface DeviceOptionsWebsocketClient extends DeviceOptionsBase<WebsocketClientOptions> {
-	type: DeviceType.WEBSOCKET_CLIENT
-}
+export type DeviceOptionsWebsocketClient = DeviceOptionsBase<DeviceType.WEBSOCKET_CLIENT, WebsocketClientOptions>
 
 export type DeviceOptionsAny =
 	| DeviceOptionsAbstract

--- a/packages/timeline-state-resolver-types/src/generated/httpSend.ts
+++ b/packages/timeline-state-resolver-types/src/generated/httpSend.ts
@@ -5,6 +5,7 @@
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
 import type { ActionExecutionResult } from "../actions"
+import type { DeviceType } from './device-options.js'
 
 export interface HttpSendOptions {
 	/**
@@ -79,6 +80,7 @@ export interface HttpSendActionMethods {
 }
 
 export interface HttpSendDeviceTypes {
+	Type: DeviceType.HTTPSEND,
 	Options: HttpSendOptions
 	Mappings: SomeMappingHttpSend
 	Actions: HttpSendActionMethods

--- a/packages/timeline-state-resolver-types/src/generated/httpWatcher.ts
+++ b/packages/timeline-state-resolver-types/src/generated/httpWatcher.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
+import type { DeviceType } from './device-options.js'
 
 export interface HttpWatcherOptions {
 	uri: string
@@ -26,6 +27,7 @@ export enum HttpMethod {
 export type SomeMappingHttpWatcher = Record<string, never>
 
 export interface HttpWatcherDeviceTypes {
+	Type: DeviceType.HTTPWATCHER,
 	Options: HttpWatcherOptions
 	Mappings: SomeMappingHttpWatcher
 	Actions: null

--- a/packages/timeline-state-resolver-types/src/generated/hyperdeck.ts
+++ b/packages/timeline-state-resolver-types/src/generated/hyperdeck.ts
@@ -5,6 +5,7 @@
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
 import type { ActionExecutionResult } from "../actions"
+import type { DeviceType } from './device-options.js'
 
 export interface HyperdeckOptions {
 	host: string
@@ -36,6 +37,7 @@ export interface HyperdeckActionMethods {
 }
 
 export interface HyperdeckDeviceTypes {
+	Type: DeviceType.HYPERDECK,
 	Options: HyperdeckOptions
 	Mappings: SomeMappingHyperdeck
 	Actions: HyperdeckActionMethods

--- a/packages/timeline-state-resolver-types/src/generated/kairos.ts
+++ b/packages/timeline-state-resolver-types/src/generated/kairos.ts
@@ -5,6 +5,7 @@
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
 import type { ActionExecutionResult } from "../actions"
+import type { DeviceType } from './device-options.js'
 
 export interface KairosOptions {
 	/**
@@ -377,6 +378,7 @@ export interface KairosActionMethods {
 }
 
 export interface KairosDeviceTypes {
+	Type: DeviceType.KAIROS,
 	Options: KairosOptions
 	Mappings: SomeMappingKairos
 	Actions: KairosActionMethods

--- a/packages/timeline-state-resolver-types/src/generated/lawo.ts
+++ b/packages/timeline-state-resolver-types/src/generated/lawo.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
+import type { DeviceType } from './device-options.js'
 
 export interface LawoOptions {
 	host: string
@@ -78,6 +79,7 @@ export enum MappingLawoType {
 export type SomeMappingLawo = MappingLawoSource | MappingLawoSources | MappingLawoFullpath | MappingLawoTriggerValue
 
 export interface LawoDeviceTypes {
+	Type: DeviceType.LAWO,
 	Options: LawoOptions
 	Mappings: SomeMappingLawo
 	Actions: null

--- a/packages/timeline-state-resolver-types/src/generated/multiOsc.ts
+++ b/packages/timeline-state-resolver-types/src/generated/multiOsc.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
+import type { DeviceType } from './device-options.js'
 
 export interface MultiOscOptions {
 	connections: {
@@ -32,6 +33,7 @@ export enum MappingMultiOscType {
 export type SomeMappingMultiOsc = MappingMultiOscLayer
 
 export interface MultiOscDeviceTypes {
+	Type: DeviceType.MULTI_OSC,
 	Options: MultiOscOptions
 	Mappings: SomeMappingMultiOsc
 	Actions: null

--- a/packages/timeline-state-resolver-types/src/generated/obs.ts
+++ b/packages/timeline-state-resolver-types/src/generated/obs.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
+import type { DeviceType } from './device-options.js'
 
 export interface ObsOptions {
 	host: string
@@ -77,6 +78,7 @@ export enum MappingObsType {
 export type SomeMappingObs = MappingObsCurrentScene | MappingObsCurrentTransition | MappingObsRecording | MappingObsStreaming | MappingObsSceneItem | MappingObsInputAudio | MappingObsInputSettings | MappingObsInputMedia
 
 export interface ObsDeviceTypes {
+	Type: DeviceType.OBS,
 	Options: ObsOptions
 	Mappings: SomeMappingObs
 	Actions: null

--- a/packages/timeline-state-resolver-types/src/generated/osc.ts
+++ b/packages/timeline-state-resolver-types/src/generated/osc.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
+import type { DeviceType } from './device-options.js'
 
 export interface OscOptions {
 	host: string
@@ -19,6 +20,7 @@ export enum OSCDeviceType {
 export type SomeMappingOsc = Record<string, never>
 
 export interface OscDeviceTypes {
+	Type: DeviceType.OSC,
 	Options: OscOptions
 	Mappings: SomeMappingOsc
 	Actions: null

--- a/packages/timeline-state-resolver-types/src/generated/panasonicPTZ.ts
+++ b/packages/timeline-state-resolver-types/src/generated/panasonicPTZ.ts
@@ -7,6 +7,7 @@
 import type { ActionExecutionResult } from "../actions"
 import type { SetPanTiltSpeedPayload, GetPanTiltPositionResult, SetZoomSpeedPayload, GetZoomPositionResult, StorePresetPayload, RecallPresetPayload, ResetPresetPayload, SetFocusSpeedPayload, SetFocusModePayload, GetFocusPositionResult, GetFocusModeResult } from './generic-ptz-actions'
 
+import type { DeviceType } from './device-options.js'
 
 export interface PanasonicPTZOptions {
 	host: string
@@ -69,6 +70,7 @@ export interface PanasonicPTZActionMethods {
 }
 
 export interface PanasonicPTZDeviceTypes {
+	Type: DeviceType.PANASONIC_PTZ,
 	Options: PanasonicPTZOptions
 	Mappings: SomeMappingPanasonicPTZ
 	Actions: PanasonicPTZActionMethods

--- a/packages/timeline-state-resolver-types/src/generated/pharos.ts
+++ b/packages/timeline-state-resolver-types/src/generated/pharos.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
+import type { DeviceType } from './device-options.js'
 
 export interface PharosOptions {
 	host: string
@@ -13,6 +14,7 @@ export interface PharosOptions {
 export type SomeMappingPharos = Record<string, never>
 
 export interface PharosDeviceTypes {
+	Type: DeviceType.PHAROS,
 	Options: PharosOptions
 	Mappings: SomeMappingPharos
 	Actions: null

--- a/packages/timeline-state-resolver-types/src/generated/quantel.ts
+++ b/packages/timeline-state-resolver-types/src/generated/quantel.ts
@@ -5,6 +5,7 @@
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
 import type { ActionExecutionResult } from "../actions"
+import type { DeviceType } from './device-options.js'
 
 export interface QuantelOptions {
 	/**
@@ -74,6 +75,7 @@ export interface QuantelActionMethods {
 }
 
 export interface QuantelDeviceTypes {
+	Type: DeviceType.QUANTEL,
 	Options: QuantelOptions
 	Mappings: SomeMappingQuantel
 	Actions: QuantelActionMethods

--- a/packages/timeline-state-resolver-types/src/generated/shotoku.ts
+++ b/packages/timeline-state-resolver-types/src/generated/shotoku.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
+import type { DeviceType } from './device-options.js'
 
 export interface ShotokuOptions {
 	host: string
@@ -13,6 +14,7 @@ export interface ShotokuOptions {
 export type SomeMappingShotoku = Record<string, never>
 
 export interface ShotokuDeviceTypes {
+	Type: DeviceType.SHOTOKU,
 	Options: ShotokuOptions
 	Mappings: SomeMappingShotoku
 	Actions: null

--- a/packages/timeline-state-resolver-types/src/generated/singularLive.ts
+++ b/packages/timeline-state-resolver-types/src/generated/singularLive.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
+import type { DeviceType } from './device-options.js'
 
 export interface SingularLiveOptions {
 	accessToken: string
@@ -21,6 +22,7 @@ export enum MappingSingularLiveType {
 export type SomeMappingSingularLive = MappingSingularLiveComposition
 
 export interface SingularLiveDeviceTypes {
+	Type: DeviceType.SINGULAR_LIVE,
 	Options: SingularLiveOptions
 	Mappings: SomeMappingSingularLive
 	Actions: null

--- a/packages/timeline-state-resolver-types/src/generated/sisyfos.ts
+++ b/packages/timeline-state-resolver-types/src/generated/sisyfos.ts
@@ -5,6 +5,7 @@
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
 import type { ActionExecutionResult } from "../actions"
+import type { DeviceType } from './device-options.js'
 
 export interface SisyfosOptions {
 	host: string
@@ -60,6 +61,7 @@ export interface SisyfosActionMethods {
 }
 
 export interface SisyfosDeviceTypes {
+	Type: DeviceType.SISYFOS,
 	Options: SisyfosOptions
 	Mappings: SomeMappingSisyfos
 	Actions: SisyfosActionMethods

--- a/packages/timeline-state-resolver-types/src/generated/sofieChef.ts
+++ b/packages/timeline-state-resolver-types/src/generated/sofieChef.ts
@@ -5,6 +5,7 @@
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
 import type { ActionExecutionResult } from "../actions"
+import type { DeviceType } from './device-options.js'
 
 export interface SofieChefOptions {
 	/**
@@ -42,6 +43,7 @@ export interface SofieChefActionMethods {
 }
 
 export interface SofieChefDeviceTypes {
+	Type: DeviceType.SOFIE_CHEF,
 	Options: SofieChefOptions
 	Mappings: SomeMappingSofieChef
 	Actions: SofieChefActionMethods

--- a/packages/timeline-state-resolver-types/src/generated/tcpSend.ts
+++ b/packages/timeline-state-resolver-types/src/generated/tcpSend.ts
@@ -5,6 +5,7 @@
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
 import type { ActionExecutionResult } from "../actions"
+import type { DeviceType } from './device-options.js'
 
 export interface TcpSendOptions {
 	host: string
@@ -43,6 +44,7 @@ export interface TcpSendActionMethods {
 }
 
 export interface TcpSendDeviceTypes {
+	Type: DeviceType.TCPSEND,
 	Options: TcpSendOptions
 	Mappings: SomeMappingTcpSend
 	Actions: TcpSendActionMethods

--- a/packages/timeline-state-resolver-types/src/generated/telemetrics.ts
+++ b/packages/timeline-state-resolver-types/src/generated/telemetrics.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
+import type { DeviceType } from './device-options.js'
 
 export interface TelemetricsOptions {
 	host: string
@@ -13,6 +14,7 @@ export interface TelemetricsOptions {
 export type SomeMappingTelemetrics = Record<string, never>
 
 export interface TelemetricsDeviceTypes {
+	Type: DeviceType.TELEMETRICS,
 	Options: TelemetricsOptions
 	Mappings: SomeMappingTelemetrics
 	Actions: null

--- a/packages/timeline-state-resolver-types/src/generated/tricaster.ts
+++ b/packages/timeline-state-resolver-types/src/generated/tricaster.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
+import type { DeviceType } from './device-options.js'
 
 export interface TricasterOptions {
 	host: string
@@ -61,6 +62,7 @@ export enum MappingTricasterType {
 export type SomeMappingTricaster = MappingTricasterME | MappingTricasterDSK | MappingTricasterINPUT | MappingTricasterAUDIOCHANNEL | MappingTricasterMIXOUTPUT | MappingTricasterMATRIXOUTPUT
 
 export interface TricasterDeviceTypes {
+	Type: DeviceType.TRICASTER,
 	Options: TricasterOptions
 	Mappings: SomeMappingTricaster
 	Actions: null

--- a/packages/timeline-state-resolver-types/src/generated/viscaOverIP.ts
+++ b/packages/timeline-state-resolver-types/src/generated/viscaOverIP.ts
@@ -7,6 +7,7 @@
 import type { ActionExecutionResult } from "../actions"
 import type { SetPanTiltSpeedPayload, GetPanTiltPositionResult, SetZoomSpeedPayload, GetZoomPositionResult, StorePresetPayload, RecallPresetPayload, ResetPresetPayload, SetFocusSpeedPayload, SetFocusModePayload, GetFocusPositionResult, GetFocusModeResult } from './generic-ptz-actions'
 
+import type { DeviceType } from './device-options.js'
 
 export interface ViscaOverIPOptions {
 	host: string
@@ -45,6 +46,7 @@ export interface ViscaOverIPActionMethods {
 }
 
 export interface ViscaOverIPDeviceTypes {
+	Type: DeviceType.VISCA_OVER_IP,
 	Options: ViscaOverIPOptions
 	Mappings: SomeMappingViscaOverIP
 	Actions: ViscaOverIPActionMethods

--- a/packages/timeline-state-resolver-types/src/generated/vizMSE.ts
+++ b/packages/timeline-state-resolver-types/src/generated/vizMSE.ts
@@ -5,6 +5,7 @@
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
 import type { ActionExecutionResult } from "../actions"
+import type { DeviceType } from './device-options.js'
 
 export interface VizMSEOptions {
 	/**
@@ -96,6 +97,7 @@ export interface VizMSEActionMethods {
 }
 
 export interface VizMSEDeviceTypes {
+	Type: DeviceType.VIZMSE,
 	Options: VizMSEOptions
 	Mappings: SomeMappingVizMSE
 	Actions: VizMSEActionMethods

--- a/packages/timeline-state-resolver-types/src/generated/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/generated/vmix.ts
@@ -5,6 +5,7 @@
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
 import type { ActionExecutionResult } from "../actions"
+import type { DeviceType } from './device-options.js'
 
 export interface VmixOptions {
 	host: string
@@ -185,6 +186,7 @@ export interface VmixActionMethods {
 }
 
 export interface VmixDeviceTypes {
+	Type: DeviceType.VMIX,
 	Options: VmixOptions
 	Mappings: SomeMappingVmix
 	Actions: VmixActionMethods

--- a/packages/timeline-state-resolver-types/src/generated/websocketClient.ts
+++ b/packages/timeline-state-resolver-types/src/generated/websocketClient.ts
@@ -5,6 +5,7 @@
  * and re-run the "tsr-schema-types" tool to regenerate this file.
  */
 import type { ActionExecutionResult } from "../actions"
+import type { DeviceType } from './device-options.js'
 
 export interface WebsocketClientOptions {
 	webSocket: {
@@ -54,6 +55,7 @@ export interface WebsocketClientActionMethods {
 }
 
 export interface WebsocketClientDeviceTypes {
+	Type: DeviceType.WEBSOCKET_CLIENT,
 	Options: WebsocketClientOptions
 	Mappings: SomeMappingWebsocketClient
 	Actions: WebsocketClientActionMethods

--- a/packages/timeline-state-resolver/src/devices/device.ts
+++ b/packages/timeline-state-resolver/src/devices/device.ts
@@ -72,7 +72,7 @@ export type DeviceEventsOLD = {
 	timeTrace: [trace: FinishedTrace]
 }
 
-export interface IDevice<TOptions extends DeviceOptionsBase<any>> {
+export interface IDevice<TOptions extends DeviceOptionsBase<any, any>> {
 	init: (initOptions: TOptions['options'], activeRundownPlaylistId: string | undefined) => Promise<boolean>
 
 	getCurrentTime: () => number
@@ -98,8 +98,8 @@ export interface IDevice<TOptions extends DeviceOptionsBase<any>> {
  * class will use.
  */
 export abstract class Device<
-		DeviceTypes extends { Options: any; Mappings: any; Actions: Record<string, any> }, // TODO: This type is not used as much as it should be, but as this class is deprecated it is not worth the effort to fix it
-		TOptions extends DeviceOptionsBase<DeviceTypes['Options']>
+		DeviceTypes extends { Type: DeviceType; Options: any; Mappings: any; Actions: Record<string, any> }, // TODO: This type is not used as much as it should be, but as this class is deprecated it is not worth the effort to fix it
+		TOptions extends DeviceOptionsBase<DeviceTypes['Type'], DeviceTypes['Options']>
 	>
 	extends EventEmitter<DeviceEvents>
 	implements IDevice<TOptions>
@@ -319,8 +319,8 @@ export abstract class Device<
  */
 export abstract class DeviceWithState<
 	TState,
-	DeviceTypes extends { Options: any; Mappings: any; Actions: Record<string, any> },
-	TOptions extends DeviceOptionsBase<DeviceTypes['Options']>
+	DeviceTypes extends { Type: DeviceType; Options: any; Mappings: any; Actions: Record<string, any> },
+	TOptions extends DeviceOptionsBase<DeviceTypes['Type'], DeviceTypes['Options']>
 > extends Device<DeviceTypes, TOptions> {
 	private _states: { [time: string]: TState } = {}
 	private _setStateCount = 0

--- a/packages/timeline-state-resolver/src/devices/deviceContainer.ts
+++ b/packages/timeline-state-resolver/src/devices/deviceContainer.ts
@@ -1,6 +1,6 @@
 import { ThreadedClass, threadedClass, ThreadedClassConfig, ThreadedClassManager } from 'threadedclass'
 import { Device } from './device'
-import { DeviceOptionsBase } from 'timeline-state-resolver-types'
+import { DeviceOptionsBase, DeviceType } from 'timeline-state-resolver-types'
 import { BaseRemoteDeviceIntegration, DeviceContainerEvents } from '../service/remoteDeviceInstance'
 
 export { DeviceContainerEvents }
@@ -10,7 +10,9 @@ export { DeviceContainerEvents }
  * keeps a local property of some basic information about the device (like
  * names and id's) to prevent a costly round trip over IPC.
  */
-export class DeviceContainer<TOptions extends DeviceOptionsBase<any>> extends BaseRemoteDeviceIntegration<TOptions> {
+export class DeviceContainer<
+	TOptions extends DeviceOptionsBase<any, any>
+> extends BaseRemoteDeviceIntegration<TOptions> {
 	protected readonly _device: ThreadedClass<Device<any, TOptions>>
 	public onChildClose: (() => void) | undefined
 
@@ -24,7 +26,7 @@ export class DeviceContainer<TOptions extends DeviceOptionsBase<any>> extends Ba
 	}
 
 	static async create<
-		TOptions extends DeviceOptionsBase<unknown>,
+		TOptions extends DeviceOptionsBase<DeviceType, unknown>,
 		TCtor extends new (...args: any[]) => Device<any, TOptions>
 	>(
 		orgModule: string,

--- a/packages/timeline-state-resolver/src/service/ConnectionManager.ts
+++ b/packages/timeline-state-resolver/src/service/ConnectionManager.ts
@@ -27,7 +27,7 @@ export interface ConnectionManagerIntEvents {
 	error: [context: string, err?: Error]
 	debug: [...debug: any[]]
 
-	connectionAdded: [id: string, container: BaseRemoteDeviceIntegration<DeviceOptionsBase<any>>]
+	connectionAdded: [id: string, container: BaseRemoteDeviceIntegration<DeviceOptionsBase<any, any>>]
 	connectionInitialised: [id: string]
 	connectionRemoved: [id: string]
 }
@@ -68,7 +68,7 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
 		this._updateConnections()
 	}
 
-	public getConnections(includeUninitialized = false): Array<BaseRemoteDeviceIntegration<DeviceOptionsBase<any>>> {
+	public getConnections(includeUninitialized = false): Array<BaseRemoteDeviceIntegration<DeviceOptionsBase<any, any>>> {
 		if (includeUninitialized) {
 			return Array.from(this._connections.values())
 		} else {
@@ -79,7 +79,7 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
 	public getConnection(
 		connectionId: string,
 		includeUninitialized = false
-	): BaseRemoteDeviceIntegration<DeviceOptionsBase<any>> | undefined {
+	): BaseRemoteDeviceIntegration<DeviceOptionsBase<any, any>> | undefined {
 		if (includeUninitialized) {
 			return this._connections.get(connectionId)
 		} else {
@@ -372,15 +372,15 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
  * consideration. In addition, the debug logging flag should be ignored as that can be changed at runtime.
  */
 function connectionConfigHasChanged(
-	connection: BaseRemoteDeviceIntegration<DeviceOptionsBase<any>>,
-	config: DeviceOptionsBase<any>
+	connection: BaseRemoteDeviceIntegration<DeviceOptionsBase<any, any>>,
+	config: DeviceOptionsBase<any, any>
 ): boolean {
 	const oldConfig = connection.deviceOptions
 
 	// now check device specific options
 	return configHasChanged(oldConfig, config)
 }
-function configHasChanged(oldConfig: DeviceOptionsBase<any>, config: DeviceOptionsBase<any>): boolean {
+function configHasChanged(oldConfig: DeviceOptionsBase<any, any>, config: DeviceOptionsBase<any, any>): boolean {
 	// now check device specific options
 	return !_.isEqual(_.omit(oldConfig, 'debug', 'debugState'), _.omit(config, 'debug', 'debugState'))
 }
@@ -391,7 +391,7 @@ function createContainer(
 	deviceId: string,
 	getCurrentTime: () => number,
 	threadedClassOptions: ThreadedClassConfig
-): Promise<BaseRemoteDeviceIntegration<DeviceOptionsBase<any>>> | null {
+): Promise<BaseRemoteDeviceIntegration<DeviceOptionsBase<any, any>>> | null {
 	switch (deviceOptions.type) {
 		case DeviceType.CASPARCG:
 			return DeviceContainer.create<DeviceOptionsCasparCGInternal, typeof CasparCGDevice>(

--- a/packages/timeline-state-resolver/src/service/remoteDeviceInstance.ts
+++ b/packages/timeline-state-resolver/src/service/remoteDeviceInstance.ts
@@ -9,7 +9,7 @@ export type DeviceContainerEvents = {
 }
 
 export abstract class BaseRemoteDeviceIntegration<
-	TOptions extends DeviceOptionsBase<any>
+	TOptions extends DeviceOptionsBase<any, any>
 > extends EventEmitter<DeviceContainerEvents> {
 	public abstract onChildClose: (() => void) | undefined
 
@@ -105,7 +105,7 @@ export abstract class BaseRemoteDeviceIntegration<
  * names and id's) to prevent a costly round trip over IPC.
  */
 export class RemoteDeviceInstance<
-	TOptions extends DeviceOptionsBase<any>
+	TOptions extends DeviceOptionsBase<any, any>
 > extends BaseRemoteDeviceIntegration<TOptions> {
 	protected _device!: ThreadedClass<DeviceInstanceWrapper>
 	public onChildClose: (() => void) | undefined
@@ -114,7 +114,7 @@ export class RemoteDeviceInstance<
 		super(deviceOptions, threadConfig)
 	}
 
-	static async create<TOptions extends DeviceOptionsBase<unknown>>(
+	static async create<TOptions extends DeviceOptionsBase<DeviceType, unknown>>(
 		pluginPath: string | null,
 		deviceId: string,
 		deviceOptions: TOptions,


### PR DESCRIPTION

## About the Contributor

This pull request is posted on behalf of the BBC

## Type of Contribution

This is a: Bug fix

## Current Behavior

This was a weird one, we appear to be hitting a limit on the size of a type union that appears as soon as one more device type is added:

<img width="1112" height="440" alt="image" src="https://github.com/user-attachments/assets/82ee6744-9222-4391-9dec-5ffeba962e2c" />

Deleting any of the existing integration types makes the error go away.  
Updating typescript to 5.7 did not resolve it.

Seems to be a designed limitation in typescript: https://github.com/microsoft/TypeScript/issues/40803  
Not 100% sure what this change does that avoids that, but it  avoids the issue

## New Behavior

Instead this reworks the types a little bit, which makes the error go away. Other than a few changes in generics, functionally nothing is really different.

We are not using this Base type in sofie-core, so this should have minimal impact outside of TSR.

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Problem

TypeScript compilation was hitting a type union complexity limit where adding one more device type triggered a cascade of compilation errors. These errors surfaced in `ConnectionManager.ts` with multiple TS2345 type assignment incompatibilities. Deleting existing device types would eliminate the errors, and upgrading to TypeScript 5.7 did not resolve the issue. The root cause was excessive variation in how `DeviceOptionsBase` type unions were being formed across the codebase.

## Solution

Reworked generated type definitions to minimize variation in type unions by making the generic type parameterization more explicit and consistent throughout the codebase.

## Key Changes

### Type Definition Changes (`packages/timeline-state-resolver-types/src/device.ts`)
- Refactored `DeviceOptionsBase` from a single generic parameter (`T`) to two explicit parameters: `TType extends DeviceType` and `TOptions`
- Updated property signatures:
  - `type: DeviceType` → `type: TType`
  - `options?: T` → `options?: TOptions`

### Generated Type Schema (`packages/timeline-state-resolver-tools/bin/schema-types.mjs`)
- Added `Type` field to generated per-directory `DeviceTypes` interfaces
- Converted per-directory `DeviceOptions` declarations from interfaces to type aliases using the new `DeviceOptionsBase<DeviceType.{DeviceTypeId}, {Dir}Options>` form
- Added import of `DeviceType` to generated output files

### Type Propagation Updates
- **`device.ts`**: Updated `Device` and `DeviceWithState` generic constraints to include `Type: DeviceType` in the `DeviceTypes` constraint and pass both `DeviceTypes['Type']` and `DeviceTypes['Options']` to `DeviceOptionsBase`
- **`conductor.ts`**: Updated internal function signatures to use `DeviceOptionsBase<any, any>` consistently across `_mapAllConnections`, device mapping, and filtering operations
- **`deviceContainer.ts`**: Updated `DeviceContainer` and its static `create` method to use the two-parameter `DeviceOptionsBase<DeviceType, unknown>`
- **`ConnectionManager.ts`**: Standardized all public event signatures and method return types to use `DeviceOptionsBase<any, any>`
- **`remoteDeviceInstance.ts`**: Updated `BaseRemoteDeviceIntegration` and `RemoteDeviceInstance` generic constraints to use `DeviceOptionsBase<any, any>`

## Impact

- Functional behavior is unchanged; this is purely a type system restructuring
- The `DeviceOptionsBase` base type changes are isolated within TSR and should have minimal impact on sofie-core, which does not directly depend on this base type
- Resolves the TypeScript compilation errors in `ConnectionManager.ts` by reducing union type complexity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->