### PR TITLE
fix: add extendable DeviceOptionsMap type for tsr-plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,20 @@ Check the main [timeline-state-resolver](/packages/timeline-state-resolver) pack
 If you are using a TSR plugin in your own project, you can easily extend the TSR types to include your own device by adding a file into your project like `tsr-extend.d.ts`:
 
 ```ts
-import type { FakeDeviceType, TimelineContentFakeAny } from './test-types.js'
+import type { FakeDeviceType, TimelineContentFakeAny, DeviceOptionsFake } from './test-types.js'
 
 declare module 'timeline-state-resolver-types' {
 	interface TimelineContentMap {
 		[FakeDeviceType]: TimelineContentFakeAny
 	}
+
+	interface DeviceOptionsMap {
+		[FakeDeviceType]: DeviceOptionsFake
+	}
 }
 ```
+
+Augmenting `DeviceOptionsMap` ensures that `DeviceOptionsAny` (the union of all device options) automatically includes your plugin's options type, enabling proper type-checking within your code wherever device options are handled.
 
 ## Development
 

--- a/packages/timeline-state-resolver-tools/bin/schema-types.mjs
+++ b/packages/timeline-state-resolver-tools/bin/schema-types.mjs
@@ -469,7 +469,12 @@ if (baseMappingsTypes.length) {
 await fs.writeFile(path.join(resolvedOutputPath, 'index.ts'), indexFile + '\n')
 
 if (isMainRepository) {
-	deviceOptionsFile += `export type DeviceOptionsAny =\n\t| ${deviceOptionsTypes.join('\n\t| ')}\n\n`
+	const deviceOptionsMapEntries = deviceOptionsTypes.map((type, i) => `\t[DeviceType.${deviceTypeEnum[i]}]: ${type}`)
+	deviceOptionsFile += `/**
+ * A map of available DeviceOptions type.
+ * TSR plugins can augment this interface to add their own device options:
+ */
+export interface DeviceOptionsMap {\n${deviceOptionsMapEntries.join('\n')}\n}\n\nexport type DeviceOptionsAny = DeviceOptionsMap[keyof DeviceOptionsMap]\n\n`
 
 	deviceOptionsFile += `/**
  * An identifier of a particular device class

--- a/packages/timeline-state-resolver-types/src/device.ts
+++ b/packages/timeline-state-resolver-types/src/device.ts
@@ -1,4 +1,4 @@
-import type { DeviceType } from '.'
+import type { DeviceTypeExt } from '.'
 import type { DeviceCommonOptions } from './generated/common-options'
 
 export enum StatusCode {
@@ -15,7 +15,9 @@ export interface DeviceStatus {
 	active: boolean
 }
 
-export interface DeviceOptionsBase<TType extends DeviceType, TOptions> extends SlowReportOptions, DeviceCommonOptions {
+export interface DeviceOptionsBase<TType extends DeviceTypeExt, TOptions>
+	extends SlowReportOptions,
+		DeviceCommonOptions {
 	type: TType
 	isMultiThreaded?: boolean
 	reportAllCommands?: boolean

--- a/packages/timeline-state-resolver-types/src/generated/device-options.ts
+++ b/packages/timeline-state-resolver-types/src/generated/device-options.ts
@@ -81,32 +81,39 @@ export type DeviceOptionsVmix = DeviceOptionsBase<DeviceType.VMIX, VmixOptions>
 import type { WebsocketClientOptions } from './websocketClient'
 export type DeviceOptionsWebsocketClient = DeviceOptionsBase<DeviceType.WEBSOCKET_CLIENT, WebsocketClientOptions>
 
-export type DeviceOptionsAny =
-	| DeviceOptionsAbstract
-	| DeviceOptionsAtem
-	| DeviceOptionsCasparCG
-	| DeviceOptionsHttpSend
-	| DeviceOptionsHttpWatcher
-	| DeviceOptionsHyperdeck
-	| DeviceOptionsKairos
-	| DeviceOptionsLawo
-	| DeviceOptionsMultiOsc
-	| DeviceOptionsObs
-	| DeviceOptionsOsc
-	| DeviceOptionsPanasonicPTZ
-	| DeviceOptionsPharos
-	| DeviceOptionsQuantel
-	| DeviceOptionsShotoku
-	| DeviceOptionsSingularLive
-	| DeviceOptionsSisyfos
-	| DeviceOptionsSofieChef
-	| DeviceOptionsTcpSend
-	| DeviceOptionsTelemetrics
-	| DeviceOptionsTricaster
-	| DeviceOptionsViscaOverIP
-	| DeviceOptionsVizMSE
-	| DeviceOptionsVmix
-	| DeviceOptionsWebsocketClient
+/**
+ * A map of available DeviceOptions type.
+ * TSR plugins can augment this interface to add their own device options:
+ */
+export interface DeviceOptionsMap {
+	[DeviceType.ABSTRACT]: DeviceOptionsAbstract
+	[DeviceType.ATEM]: DeviceOptionsAtem
+	[DeviceType.CASPARCG]: DeviceOptionsCasparCG
+	[DeviceType.HTTPSEND]: DeviceOptionsHttpSend
+	[DeviceType.HTTPWATCHER]: DeviceOptionsHttpWatcher
+	[DeviceType.HYPERDECK]: DeviceOptionsHyperdeck
+	[DeviceType.KAIROS]: DeviceOptionsKairos
+	[DeviceType.LAWO]: DeviceOptionsLawo
+	[DeviceType.MULTI_OSC]: DeviceOptionsMultiOsc
+	[DeviceType.OBS]: DeviceOptionsObs
+	[DeviceType.OSC]: DeviceOptionsOsc
+	[DeviceType.PANASONIC_PTZ]: DeviceOptionsPanasonicPTZ
+	[DeviceType.PHAROS]: DeviceOptionsPharos
+	[DeviceType.QUANTEL]: DeviceOptionsQuantel
+	[DeviceType.SHOTOKU]: DeviceOptionsShotoku
+	[DeviceType.SINGULAR_LIVE]: DeviceOptionsSingularLive
+	[DeviceType.SISYFOS]: DeviceOptionsSisyfos
+	[DeviceType.SOFIE_CHEF]: DeviceOptionsSofieChef
+	[DeviceType.TCPSEND]: DeviceOptionsTcpSend
+	[DeviceType.TELEMETRICS]: DeviceOptionsTelemetrics
+	[DeviceType.TRICASTER]: DeviceOptionsTricaster
+	[DeviceType.VISCA_OVER_IP]: DeviceOptionsViscaOverIP
+	[DeviceType.VIZMSE]: DeviceOptionsVizMSE
+	[DeviceType.VMIX]: DeviceOptionsVmix
+	[DeviceType.WEBSOCKET_CLIENT]: DeviceOptionsWebsocketClient
+}
+
+export type DeviceOptionsAny = DeviceOptionsMap[keyof DeviceOptionsMap]
 
 /**
  * An identifier of a particular device class

--- a/packages/timeline-state-resolver-types/src/mapping.ts
+++ b/packages/timeline-state-resolver-types/src/mapping.ts
@@ -1,11 +1,11 @@
 import { Content, ResolvedTimelineObjectInstance } from './superfly-timeline'
-import { DeviceType, TSRTimelineContent } from '.'
+import { DeviceTypeExt, TSRTimelineContent } from '.'
 
 export interface Mappings<TOptions extends { mappingType: string } | unknown = unknown> {
 	[layerName: string]: Mapping<TOptions>
 }
 
-export interface Mapping<TOptions extends { mappingType: string } | unknown, TType = DeviceType> {
+export interface Mapping<TOptions extends { mappingType: string } | unknown, TType = DeviceTypeExt> {
 	device: TType // TODO - is this helpful being generic?
 	deviceId: string
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of Superfly

## Type of Contribution

This is a: Bug fix / Feature 

## Current Behavior

When using a tsr-plugin it is possible to extend the timeline content types, but not the device options types.


## New Behavior

This gives the device options similar treatment

TODO: The docs in sofie-core should be updated with an example, and to note that this `tsr-extend.d.ts` should be referenced in the tsconfig `types` array:
```
{
	"compilerOptions": {
		"types": ["node", "./src/tsr-extend.d.ts"],
	}
}
```

<!--
What is the new behavior?
-->

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.