### PR TITLE
feat: casparcg scaleMode support

### DIFF
--- a/packages/timeline-state-resolver-types/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/timeline-state-resolver-types/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -11,6 +11,7 @@ exports[`index imports 1`] = `
   "BlendMode",
   "BorderBevel",
   "CasparCGActions",
+  "CasparCGScaleMode",
   "ChannelFormat",
   "Chroma",
   "DeviceType",

--- a/packages/timeline-state-resolver-types/src/__tests__/casparcg.spec.ts
+++ b/packages/timeline-state-resolver-types/src/__tests__/casparcg.spec.ts
@@ -1,0 +1,8 @@
+import { Enum } from 'casparcg-connection'
+import { CasparCGScaleMode } from '../index.js'
+
+describe('CasparCG types', () => {
+	test('CasparCGScaleMode', async () => {
+		expect(CasparCGScaleMode).toEqual(Enum.ProducerScaleMode)
+	})
+})

--- a/packages/timeline-state-resolver-types/src/integrations/casparcg.ts
+++ b/packages/timeline-state-resolver-types/src/integrations/casparcg.ts
@@ -86,6 +86,8 @@ export interface TimelineContentCCGMedia extends TimelineContentCasparCGBase, Ti
 	/* ffmpeg filter strings for 2.3+ */
 	videoFilter?: string
 	audioFilter?: string
+	/** Scale mode for the producer. Since CasparCG 2.5.0 */
+	scaleMode?: CasparCGScaleMode
 }
 export interface TimelineContentCCGIP extends TimelineContentCasparCGBase, TimelineContentCCGProducerBase {
 	type: TimelineContentTypeCasparCg.IP
@@ -98,6 +100,8 @@ export interface TimelineContentCCGIP extends TimelineContentCasparCGBase, Timel
 	/* ffmpeg filter strings for 2.3+ */
 	videoFilter?: string
 	audioFilter?: string
+	/** Scale mode for the producer. Since CasparCG 2.5.0 */
+	scaleMode?: CasparCGScaleMode
 }
 export interface TimelineContentCCGInput extends TimelineContentCasparCGBase, TimelineContentCCGProducerBase {
 	type: TimelineContentTypeCasparCg.INPUT
@@ -163,6 +167,16 @@ export interface TimelineContentCCGRecord extends TimelineContentCasparCGBase {
 	file: string
 	/** ffmpeg encoder options (example '-vcodec libx264 -preset ultrafast') */
 	encoderOptions: string
+}
+
+/** Scale mode for the ffmpeg/image producer. Since CasparCG 2.5.0. */
+export enum CasparCGScaleMode {
+	STRETCH = 'STRETCH',
+	FIT = 'FIT',
+	FILL = 'FILL',
+	ORIGINAL = 'ORIGINAL',
+	HFILL = 'HFILL',
+	VFILL = 'VFILL',
 }
 
 // Note: enums copied from casparcg-connection

--- a/packages/timeline-state-resolver/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/timeline-state-resolver/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -13,6 +13,7 @@ exports[`index imports 1`] = `
   "BorderBevel",
   "CasparCGActions",
   "CasparCGDevice",
+  "CasparCGScaleMode",
   "ChannelFormat",
   "Chroma",
   "Conductor",

--- a/packages/timeline-state-resolver/src/integrations/casparCG/__tests__/casparcg.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/__tests__/casparcg.spec.ts
@@ -1,6 +1,7 @@
 import { Conductor } from '../../../conductor.js'
 import {
 	TimelineContentTypeCasparCg,
+	CasparCGScaleMode,
 	SomeMappingCasparCG,
 	Mappings,
 	DeviceType,
@@ -2196,6 +2197,71 @@ describe('CasparCG', () => {
 			channel: 2,
 			layer: 42,
 			seek: 0,
+		})
+	})
+	test('CasparCG: Play with scaleMode', async () => {
+		const commandReceiver0: any = jest.fn(async () => {
+			return Promise.resolve()
+		})
+		const myLayerMapping0: Mapping<SomeMappingCasparCG> = {
+			device: DeviceType.CASPARCG,
+			deviceId: 'myCCG',
+			options: {
+				mappingType: MappingCasparCGType.Layer,
+				channel: 2,
+				layer: 42,
+			},
+		}
+		const myLayerMapping: Mappings = {
+			myLayer0: myLayerMapping0,
+		}
+
+		const myConductor = new Conductor({
+			multiThreadedResolver: false,
+			getCurrentTime: mockTime.getCurrentTime,
+		})
+		await myConductor.init()
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
+			},
+		})
+		await mockTime.advanceTimeToTicks(10100)
+		commandReceiver0.mockClear()
+
+		myConductor.setTimelineAndMappings(
+			[
+				{
+					id: 'obj0',
+					enable: {
+						start: mockTime.getCurrentTime() - 1000, // 1 second ago
+						duration: 2000,
+					},
+					layer: 'myLayer0',
+					content: {
+						deviceType: DeviceType.CASPARCG,
+						type: TimelineContentTypeCasparCg.MEDIA,
+						file: 'AMB',
+						scaleMode: CasparCGScaleMode.FIT,
+					},
+				},
+			],
+			myLayerMapping
+		)
+
+		await mockTime.advanceTimeToTicks(10200)
+
+		expect(commandReceiver0).toHaveBeenCalledTimes(1)
+		expect(getMockCall(commandReceiver0, 0, 1).params).toMatchObject({
+			channel: 2,
+			layer: 42,
+			clip: 'AMB',
+			scaleMode: 'FIT',
 		})
 	})
 })

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -64,6 +64,7 @@ import type {
 	DeviceTimelineState,
 	DeviceTimelineStateObject,
 } from 'timeline-state-resolver-api'
+import { convertScaleModeToConnection } from './util.js'
 
 const debug = Debug('timeline-state-resolver:casparcg')
 
@@ -340,6 +341,7 @@ export class CasparCGDevice extends DeviceWithState<State, CasparCGDeviceTypes, 
 
 				vfilter: content.videoFilter,
 				afilter: content.audioFilter,
+				scaleMode: convertScaleModeToConnection(content.scaleMode),
 			})
 			// this.emitDebug(stateLayer)
 		} else if (content.type === TimelineContentTypeCasparCg.IP) {
@@ -355,6 +357,7 @@ export class CasparCGDevice extends DeviceWithState<State, CasparCGDeviceTypes, 
 
 				vfilter: content.videoFilter,
 				afilter: content.audioFilter,
+				scaleMode: convertScaleModeToConnection(content.scaleMode),
 			})
 		} else if (content.type === TimelineContentTypeCasparCg.INPUT) {
 			stateLayer = literal<InputLayer>({

--- a/packages/timeline-state-resolver/src/integrations/casparCG/util.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/util.ts
@@ -1,0 +1,9 @@
+import { Enum } from 'casparcg-connection'
+import { CasparCGScaleMode } from 'timeline-state-resolver-types'
+
+export function convertScaleModeToConnection(
+	scaleMode: CasparCGScaleMode | undefined
+): Enum.ProducerScaleMode | undefined {
+	// There is a unit test to ensure that these align
+	return scaleMode as unknown as Enum.ProducerScaleMode | undefined
+}


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the BBC

## Type of Contribution

This is a: Feature 

## Current Behavior

<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

## New Behavior

This is built on top of #448, which updates the library and tackles the build issues

This exposes the [casparcg SCALE_MODE amcp property](https://github.com/CasparCG/server/pull/1566) to the timeline

Depends upon https://github.com/SuperFlyTV/casparcg-connection/pull/224 and https://github.com/SuperFlyTV/casparcg-state/pull/96

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
