### PR TITLE
fix: atem not controlling dip transition SOFIE-496

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/atem/__tests__/__snapshots__/diffStates.spec.ts.snap
+++ b/packages/timeline-state-resolver/src/integrations/atem/__tests__/__snapshots__/diffStates.spec.ts.snap
@@ -45,7 +45,7 @@ exports[`Diff States Simple diff against empty state 1`] = `
       "transitionProperties": true,
       "transitionSettings": {
         "DVE": false,
-        "dip": false,
+        "dip": true,
         "mix": true,
         "stinger": true,
         "wipe": true,

--- a/packages/timeline-state-resolver/src/integrations/atem/diffState.ts
+++ b/packages/timeline-state-resolver/src/integrations/atem/diffState.ts
@@ -60,7 +60,7 @@ export function createDiffOptions(mappings: Mappings<SomeMappingAtem>): DeepComp
 				transitionStatus: true,
 				transitionProperties: true,
 				transitionSettings: {
-					dip: false,
+					dip: true,
 					DVE: false,
 					mix: true,
 					stinger: true,


### PR DESCRIPTION


## About the Contributor

This pull request is posted on behalf of the BBC

## Type of Contribution

This is a: Bug fix 

## Current Behavior

An object containing the below has no effect

```
content: {
	deviceType: DeviceType.ATEM,
	type: TimelineContentTypeAtem.ME,
	me: {
		transition: AtemTransitionStyle.DIP,
		transitionSettings: {
			dip: {
				rate: 100,
				input: 1,
			},
		},
	},
},
```

## New Behavior

This is now fixed, the state differ was ignoring these properties

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
