### PR TITLE
fix: Listen for errors from casparcg and pass them on

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -199,6 +199,10 @@ export class CasparCGDevice extends DeviceWithState<State, CasparCGDeviceTypes, 
 				})
 		})
 
+		this._ccg.on('error', (e) => {
+			this.emit('error', 'CasparCG connection error', e)
+		})
+
 		this._ccg.on('disconnect', () => {
 			this._connected = false
 			this._connectionChanged()


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the BBC.

## Type of Contribution

This is a Bug fix

## Current Behavior

When the CasparCG connection encounters a network error (e.g. `ETIMEDOUT`), the error is emitted as an `'error'` event on the `BasicCasparCGAPI` instance. Since no listener was registered for this event, Node.js's `EventEmitter` throws it as an uncaught exception, crashing the playout-gateway process.

This became a problem with the upgrade to `casparcg-connection` 7.x (introduced in TSR nightly around April 2026). In version 6.x, connection errors were handled internally and never propagated to the caller. In version 7.x, they are emitted as `'error'` events on the API object.

On Node.js v22+, with Happy Eyeballs (`autoSelectFamily`) enabled by default, failed connection attempts produce an `AggregateError` rather than a plain `Error`, which made the unhandled error particularly visible.

## New Behavior

`CasparCGDevice` now registers a listener for `'error'` events on the `BasicCasparCGAPI` instance and forwards them through the standard TSR device error chain (`this.emit('error', context, err)`). The error is then handled by `ConnectionManager` and logged by the playout-gateway, rather than crashing the process.

## Testing Instructions

- Point a Sofie/TSR setup with `casparcg-connection` 7.x at an unreachable CasparCG server (e.g. wrong IP or a firewalled host).
- Before this fix: the playout-gateway process crashes with an `AggregateError [ETIMEDOUT]`.
- After this fix: the connection error is logged as a device error and the gateway continues running.


## Other Information

The root cause was identified by inspecting the `ConnectionEvents` type in `casparcg-connection/dist/api.d.ts`, which declares:

```ts
export type ConnectionEvents = {
    connect: [];
    disconnect: [];
    error: [error: Error];
};
```

The `'connect'` and `'disconnect'` events were already handled in TSR; `'error'` was not. The fix adds the missing handler, matching the pattern used by other TSR device integrations.

## Status

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
