### PR TITLE
feat: add structured error codes and context to ActionExecutionResult

### DIFF
--- a/packages/timeline-state-resolver-types/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/timeline-state-resolver-types/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -12,6 +12,8 @@ exports[`index imports 1`] = `
   "AtemTransitionStyle",
   "BlendMode",
   "BorderBevel",
+  "CasparCGActionErrorCode",
+  "CasparCGActionErrorMessages",
   "CasparCGActions",
   "CasparCGScaleMode",
   "CasparCGStatusCode",

--- a/packages/timeline-state-resolver-types/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/timeline-state-resolver-types/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -28,6 +28,8 @@ exports[`index imports 1`] = `
   "HTTPWatcherStatusCode",
   "HTTPWatcherStatusMessages",
   "HttpMethod",
+  "HttpSendActionErrorCode",
+  "HttpSendActionErrorMessages",
   "HttpSendActions",
   "HyperdeckActions",
   "HyperdeckStatusCode",

--- a/packages/timeline-state-resolver-types/src/actions.ts
+++ b/packages/timeline-state-resolver-types/src/actions.ts
@@ -1,11 +1,42 @@
 import type { ITranslatableMessage } from './translations.js'
 
+/**
+ * The result of executing a device action.
+ *
+ * On error, `response` is the pre-rendered human-readable fallback message. Consumers who want
+ * to customise the message can use `code` and `context` to look up and interpolate a custom
+ * template (e.g. from a blueprint's `deviceActionErrorMessages` map).
+ *
+ * Action error codes follow the pattern: ACTION_{DEVICETYPE}_{REASON}
+ *
+ * @example
+ * // Device returns a structured error:
+ * {
+ *   result: ActionExecutionResultCode.Error,
+ *   response: { key: 'CasparCG launcher host not configured' },
+ *   code: 'ACTION_CASPARCG_LAUNCHER_HOST_NOT_SET',
+ *   context: { deviceName: 'CasparCG 1', host: '192.168.1.10' },
+ * }
+ *
+ * // Consumer applies a custom template:
+ * interpolateTemplateString('{{deviceName}}: launcher host not set ({{host}})', result.context)
+ */
 export interface ActionExecutionResult<ResultData = void> {
 	result: ActionExecutionResultCode
-	/** Response message, intended to be displayed to a user */
+	/** Pre-rendered human-readable response message, intended to be displayed to a user */
 	response?: ITranslatableMessage
 	/** Response data */
 	resultData?: ResultData
+	/**
+	 * Structured error code for customisable messages - typically ACTION_{DEVICETYPE}_{REASON}.
+	 * Present on structured errors alongside `context`.
+	 */
+	code?: string
+	/**
+	 * Context for custom message interpolation via interpolateTemplateString().
+	 * Present on structured errors alongside `code`.
+	 */
+	context?: Record<string, unknown>
 }
 
 export enum ActionExecutionResultCode {

--- a/packages/timeline-state-resolver-types/src/integrations/casparcg/timeline.ts
+++ b/packages/timeline-state-resolver-types/src/integrations/casparcg/timeline.ts
@@ -43,6 +43,89 @@ export const CasparCGStatusMessages: Record<CasparCGStatusCode, string> = {
 	[CasparCGStatusCode.QUEUE_OVERFLOW]: 'CasparCG command queue overflow',
 }
 
+/**
+ * Action error codes for CasparCG device actions.
+ * These codes can be customized in blueprints via deviceActionErrorMessages.
+ *
+ * Error codes follow the pattern: ACTION_CASPARCG_{ACTION}_{REASON}
+ */
+export const CasparCGActionErrorCode = {
+	// ClearAllChannels errors
+	/** ClearAllChannels: no connection to CasparCG */
+	CLEAR_NO_CONNECTION: 'ACTION_CASPARCG_CLEAR_NO_CONNECTION',
+	/** ClearAllChannels: failed to execute INFO command */
+	CLEAR_INFO_FAILED: 'ACTION_CASPARCG_CLEAR_INFO_FAILED',
+	/** ClearAllChannels: no channel data returned from INFO command */
+	CLEAR_NO_CHANNELS: 'ACTION_CASPARCG_CLEAR_NO_CHANNELS',
+
+	// RestartServer errors
+	/** RestartServer: device not initialized (no connection options) */
+	RESTART_NOT_INITIALIZED: 'ACTION_CASPARCG_RESTART_NOT_INITIALIZED',
+	/** RestartServer: launcher host not configured */
+	RESTART_LAUNCHER_HOST_NOT_SET: 'ACTION_CASPARCG_RESTART_LAUNCHER_HOST_NOT_SET',
+	/** RestartServer: launcher port not configured */
+	RESTART_LAUNCHER_PORT_NOT_SET: 'ACTION_CASPARCG_RESTART_LAUNCHER_PORT_NOT_SET',
+	/** RestartServer: launcher process not configured */
+	RESTART_LAUNCHER_PROCESS_NOT_SET: 'ACTION_CASPARCG_RESTART_LAUNCHER_PROCESS_NOT_SET',
+	/** RestartServer: launcher returned a non-200 HTTP status */
+	RESTART_BAD_REPLY: 'ACTION_CASPARCG_RESTART_BAD_REPLY',
+	/** RestartServer: network request to launcher failed */
+	RESTART_REQUEST_FAILED: 'ACTION_CASPARCG_RESTART_REQUEST_FAILED',
+
+	// ListMedia errors
+	/** ListMedia: device not initialized */
+	LIST_NOT_INITIALIZED: 'ACTION_CASPARCG_LIST_NOT_INITIALIZED',
+	/** ListMedia: CLS command returned an error */
+	LIST_CLS_ERROR: 'ACTION_CASPARCG_LIST_CLS_ERROR',
+	/** ListMedia: CLS command returned a non-200 response code */
+	LIST_BAD_RESPONSE: 'ACTION_CASPARCG_LIST_BAD_RESPONSE',
+} as const
+
+export type CasparCGActionErrorCode = (typeof CasparCGActionErrorCode)[keyof typeof CasparCGActionErrorCode]
+
+/**
+ * Default human-readable messages for each CasparCG action error code.
+ * Used as fallback when no blueprint customization is present.
+ */
+export const CasparCGActionErrorMessages: Record<CasparCGActionErrorCode, string> = {
+	[CasparCGActionErrorCode.CLEAR_NO_CONNECTION]: 'Cannot clear CasparCG channels: no connection',
+	[CasparCGActionErrorCode.CLEAR_INFO_FAILED]: 'Cannot clear CasparCG channels: failed to retrieve channel info',
+	[CasparCGActionErrorCode.CLEAR_NO_CHANNELS]: 'Cannot clear CasparCG channels: no channels found',
+
+	[CasparCGActionErrorCode.RESTART_NOT_INITIALIZED]: 'Cannot restart CasparCG: device not initialized',
+	[CasparCGActionErrorCode.RESTART_LAUNCHER_HOST_NOT_SET]: 'Cannot restart CasparCG: launcher host not configured',
+	[CasparCGActionErrorCode.RESTART_LAUNCHER_PORT_NOT_SET]: 'Cannot restart CasparCG: launcher port not configured',
+	[CasparCGActionErrorCode.RESTART_LAUNCHER_PROCESS_NOT_SET]:
+		'Cannot restart CasparCG: launcher process not configured',
+	[CasparCGActionErrorCode.RESTART_BAD_REPLY]: 'CasparCG restart failed: launcher returned {{statusCode}} {{body}}',
+	[CasparCGActionErrorCode.RESTART_REQUEST_FAILED]: 'CasparCG restart failed: {{errorMessage}}',
+
+	[CasparCGActionErrorCode.LIST_NOT_INITIALIZED]: 'Cannot list CasparCG media: device not initialized',
+	[CasparCGActionErrorCode.LIST_CLS_ERROR]: 'CasparCG media list failed: {{errorMessage}}',
+	[CasparCGActionErrorCode.LIST_BAD_RESPONSE]: 'CasparCG media list failed: server returned error {{responseCode}}',
+}
+
+/**
+ * Context data for each CasparCG action error code.
+ * These fields are available for message template interpolation.
+ */
+export interface CasparCGActionErrorContextMap {
+	[CasparCGActionErrorCode.CLEAR_NO_CONNECTION]: Record<string, never>
+	[CasparCGActionErrorCode.CLEAR_INFO_FAILED]: Record<string, never>
+	[CasparCGActionErrorCode.CLEAR_NO_CHANNELS]: Record<string, never>
+
+	[CasparCGActionErrorCode.RESTART_NOT_INITIALIZED]: Record<string, never>
+	[CasparCGActionErrorCode.RESTART_LAUNCHER_HOST_NOT_SET]: Record<string, never>
+	[CasparCGActionErrorCode.RESTART_LAUNCHER_PORT_NOT_SET]: Record<string, never>
+	[CasparCGActionErrorCode.RESTART_LAUNCHER_PROCESS_NOT_SET]: Record<string, never>
+	[CasparCGActionErrorCode.RESTART_BAD_REPLY]: { statusCode: number; body: string }
+	[CasparCGActionErrorCode.RESTART_REQUEST_FAILED]: { errorMessage: string }
+
+	[CasparCGActionErrorCode.LIST_NOT_INITIALIZED]: Record<string, never>
+	[CasparCGActionErrorCode.LIST_CLS_ERROR]: { errorMessage: string }
+	[CasparCGActionErrorCode.LIST_BAD_RESPONSE]: { responseCode: number }
+}
+
 export enum TimelineContentTypeCasparCg {
 	//  CasparCG-state
 	MEDIA = 'media',

--- a/packages/timeline-state-resolver-types/src/integrations/httpSend/timeline.ts
+++ b/packages/timeline-state-resolver-types/src/integrations/httpSend/timeline.ts
@@ -10,3 +10,52 @@ export interface HTTPSendCommandContentExt extends Omit<HTTPSendCommandContent, 
 }
 
 export type TimelineContentHTTPRequest = TimelineContentHTTPSendBase & HTTPSendCommandContentExt
+
+/**
+ * Action error codes for HTTP Send device actions.
+ * These codes can be customized in blueprints via deviceActionErrorMessages.
+ *
+ * Error codes follow the pattern: ACTION_HTTPSEND_{REASON}
+ */
+export const HttpSendActionErrorCode = {
+	/** SendCommand action was called without a payload */
+	MISSING_PAYLOAD: 'ACTION_HTTPSEND_MISSING_PAYLOAD',
+	/** SendCommand action payload is missing a URL */
+	MISSING_URL: 'ACTION_HTTPSEND_MISSING_URL',
+	/** SendCommand action payload has an invalid HTTP method type */
+	INVALID_TYPE: 'ACTION_HTTPSEND_INVALID_TYPE',
+	/** SendCommand action payload is missing params */
+	MISSING_PARAMS: 'ACTION_HTTPSEND_MISSING_PARAMS',
+	/** SendCommand action payload has an invalid params type */
+	INVALID_PARAMS_TYPE: 'ACTION_HTTPSEND_INVALID_PARAMS_TYPE',
+	/** HTTP request failed with a network error */
+	REQUEST_FAILED: 'ACTION_HTTPSEND_REQUEST_FAILED',
+} as const
+
+export type HttpSendActionErrorCode = (typeof HttpSendActionErrorCode)[keyof typeof HttpSendActionErrorCode]
+
+/**
+ * Default human-readable messages for each HTTP Send action error code.
+ * Used as fallback when no blueprint customization is present.
+ */
+export const HttpSendActionErrorMessages: Record<HttpSendActionErrorCode, string> = {
+	[HttpSendActionErrorCode.MISSING_PAYLOAD]: 'Failed to send HTTP command: missing payload',
+	[HttpSendActionErrorCode.MISSING_URL]: 'Failed to send HTTP command: missing URL',
+	[HttpSendActionErrorCode.INVALID_TYPE]: 'Failed to send HTTP command: invalid HTTP method type',
+	[HttpSendActionErrorCode.MISSING_PARAMS]: 'Failed to send HTTP command: missing params',
+	[HttpSendActionErrorCode.INVALID_PARAMS_TYPE]: 'Failed to send HTTP command: invalid params type',
+	[HttpSendActionErrorCode.REQUEST_FAILED]: 'HTTP request to {{url}} failed: {{errorMessage}}',
+}
+
+/**
+ * Context data for each HTTP Send action error code.
+ * These fields are available for message template interpolation.
+ */
+export interface HttpSendActionErrorContextMap {
+	[HttpSendActionErrorCode.MISSING_PAYLOAD]: Record<string, never>
+	[HttpSendActionErrorCode.MISSING_URL]: Record<string, never>
+	[HttpSendActionErrorCode.INVALID_TYPE]: { type: string }
+	[HttpSendActionErrorCode.MISSING_PARAMS]: { url: string }
+	[HttpSendActionErrorCode.INVALID_PARAMS_TYPE]: { paramsType: string }
+	[HttpSendActionErrorCode.REQUEST_FAILED]: { url: string; errorMessage: string; errorCode?: string }
+}

--- a/packages/timeline-state-resolver/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/timeline-state-resolver/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -35,6 +35,8 @@ exports[`index imports 1`] = `
   "HTTPWatcherStatusCode",
   "HTTPWatcherStatusMessages",
   "HttpMethod",
+  "HttpSendActionErrorCode",
+  "HttpSendActionErrorMessages",
   "HttpSendActions",
   "HyperdeckActions",
   "HyperdeckDevice",

--- a/packages/timeline-state-resolver/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/timeline-state-resolver/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -13,6 +13,8 @@ exports[`index imports 1`] = `
   "AtemTransitionStyle",
   "BlendMode",
   "BorderBevel",
+  "CasparCGActionErrorCode",
+  "CasparCGActionErrorMessages",
   "CasparCGActions",
   "CasparCGDevice",
   "CasparCGScaleMode",

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -34,6 +34,7 @@ import {
 	CasparCGStatusCode,
 	DeviceStatusDetail,
 	DeviceStatusInput,
+	CasparCGActionErrorCode,
 } from 'timeline-state-resolver-types'
 import { createCasparCGStatusDetail } from './messages.js'
 
@@ -633,17 +634,29 @@ export class CasparCGDevice extends DeviceWithState<State, CasparCGDeviceTypes, 
 		if (!this._ccg?.connected) {
 			return {
 				result: ActionExecutionResultCode.Error,
-				response: t('Cannot restart CasparCG without a connection'),
+				code: CasparCGActionErrorCode.CLEAR_NO_CONNECTION,
+				context: {},
+				response: t('Cannot clear CasparCG channels: no connection'),
 			}
 		}
 
 		const { error, request } = await this._ccg.executeCommand({ command: Commands.Info, params: {} })
 		if (error) {
-			return { result: ActionExecutionResultCode.Error }
+			return {
+				result: ActionExecutionResultCode.Error,
+				code: CasparCGActionErrorCode.CLEAR_INFO_FAILED,
+				context: {},
+				response: t('Cannot clear CasparCG channels: failed to get channel info'),
+			}
 		}
 		const response = await request
 		if (!response?.data[0]) {
-			return { result: ActionExecutionResultCode.Error }
+			return {
+				result: ActionExecutionResultCode.Error,
+				code: CasparCGActionErrorCode.CLEAR_NO_CHANNELS,
+				context: {},
+				response: t('Cannot clear CasparCG channels: no channels found'),
+			}
 		}
 
 		await Promise.all(
@@ -697,18 +710,35 @@ export class CasparCGDevice extends DeviceWithState<State, CasparCGDeviceTypes, 
 	 */
 	private async restartCasparCG(): Promise<ActionExecutionResult> {
 		if (!this.initOptions) {
-			return { result: ActionExecutionResultCode.Error, response: t('CasparCGDevice._connectionOptions is not set!') }
+			return {
+				result: ActionExecutionResultCode.Error,
+				code: CasparCGActionErrorCode.RESTART_NOT_INITIALIZED,
+				context: {},
+				response: t('Cannot restart CasparCG: device not initialized'),
+			}
 		}
 		if (!this.initOptions.launcherHost) {
-			return { result: ActionExecutionResultCode.Error, response: t('CasparCGDevice: config.launcherHost is not set!') }
+			return {
+				result: ActionExecutionResultCode.Error,
+				code: CasparCGActionErrorCode.RESTART_LAUNCHER_HOST_NOT_SET,
+				context: {},
+				response: t('Cannot restart CasparCG: launcher host not configured'),
+			}
 		}
 		if (!this.initOptions.launcherPort) {
-			return { result: ActionExecutionResultCode.Error, response: t('CasparCGDevice: config.launcherPort is not set!') }
+			return {
+				result: ActionExecutionResultCode.Error,
+				code: CasparCGActionErrorCode.RESTART_LAUNCHER_PORT_NOT_SET,
+				context: {},
+				response: t('Cannot restart CasparCG: launcher port not configured'),
+			}
 		}
 		if (!this.initOptions.launcherProcess) {
 			return {
 				result: ActionExecutionResultCode.Error,
-				response: t('CasparCGDevice: config.launcherProcess is not set!'),
+				code: CasparCGActionErrorCode.RESTART_LAUNCHER_PROCESS_NOT_SET,
+				context: {},
+				response: t('Cannot restart CasparCG: launcher process not configured'),
 			}
 		}
 
@@ -725,7 +755,9 @@ export class CasparCGDevice extends DeviceWithState<State, CasparCGDeviceTypes, 
 				} else {
 					return {
 						result: ActionExecutionResultCode.Error,
-						response: t('Bad reply: [{{statusCode}}] {{body}}', {
+						code: CasparCGActionErrorCode.RESTART_BAD_REPLY,
+						context: { statusCode: response.statusCode, body: response.body },
+						response: t('CasparCG restart failed: launcher returned {{statusCode}} {{body}}', {
 							statusCode: response.statusCode,
 							body: response.body,
 						}),
@@ -735,8 +767,10 @@ export class CasparCGDevice extends DeviceWithState<State, CasparCGDeviceTypes, 
 			.catch((error) => {
 				return {
 					result: ActionExecutionResultCode.Error,
-					response: t('{{message}}', {
-						message: error.toString(),
+					code: CasparCGActionErrorCode.RESTART_REQUEST_FAILED,
+					context: { errorMessage: error.toString() },
+					response: t('CasparCG restart failed: {{errorMessage}}', {
+						errorMessage: error.toString(),
 					}),
 				}
 			})
@@ -745,7 +779,9 @@ export class CasparCGDevice extends DeviceWithState<State, CasparCGDeviceTypes, 
 		if (!this._ccg) {
 			return {
 				result: ActionExecutionResultCode.Error,
-				response: t('CasparCG device not initialized'),
+				code: CasparCGActionErrorCode.LIST_NOT_INITIALIZED,
+				context: {},
+				response: t('Cannot list CasparCG media: device not initialized'),
 			}
 		}
 		const result = await this._ccg.executeCommand(
@@ -757,7 +793,9 @@ export class CasparCGDevice extends DeviceWithState<State, CasparCGDeviceTypes, 
 		if (result.error)
 			return {
 				result: ActionExecutionResultCode.Error,
-				response: t(`Error message from CasparCG: {{message}}`, { message: `${result.error}` }),
+				code: CasparCGActionErrorCode.LIST_CLS_ERROR,
+				context: { errorMessage: `${result.error}` },
+				response: t(`CasparCG media list failed: {{errorMessage}}`, { errorMessage: `${result.error}` }),
 			}
 
 		const request = await result.request
@@ -770,7 +808,11 @@ export class CasparCGDevice extends DeviceWithState<State, CasparCGDeviceTypes, 
 		} else {
 			return {
 				result: ActionExecutionResultCode.Error,
-				response: t(`Error code {{code}} from CasparCG`, { code: request.responseCode }),
+				code: CasparCGActionErrorCode.LIST_BAD_RESPONSE,
+				context: { responseCode: request.responseCode },
+				response: t(`CasparCG media list failed: server returned error {{responseCode}}`, {
+					responseCode: request.responseCode,
+				}),
 			}
 		}
 	}

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -4,6 +4,7 @@ import {
 	HTTPSendCommandContent,
 	HTTPSendCommandContentExt,
 	HttpSendOptions,
+	HttpSendActionErrorCode,
 	SendCommandResult,
 	StatusCode,
 	TSRTimelineContent,
@@ -85,30 +86,40 @@ export class HTTPSendDevice implements Device<HttpSendDeviceTypes, HttpSendDevic
 		if (!cmd)
 			return {
 				result: ActionExecutionResultCode.Error,
-				response: t('Failed to send command: Missing payloadurl'),
+				response: t('Failed to send command: Missing payload'),
+				code: HttpSendActionErrorCode.MISSING_PAYLOAD,
+				context: {},
 			}
 		if (!cmd.url) {
 			return {
 				result: ActionExecutionResultCode.Error,
 				response: t('Failed to send command: Missing url'),
+				code: HttpSendActionErrorCode.MISSING_URL,
+				context: {},
 			}
 		}
 		if (!Object.values<TimelineContentTypeHTTP>(TimelineContentTypeHTTP).includes(cmd.type)) {
 			return {
 				result: ActionExecutionResultCode.Error,
 				response: t('Failed to send command: type is invalid'),
+				code: HttpSendActionErrorCode.INVALID_TYPE,
+				context: { type: cmd.type },
 			}
 		}
 		if (!cmd.params) {
 			return {
 				result: ActionExecutionResultCode.Error,
 				response: t('Failed to send command: Missing params'),
+				code: HttpSendActionErrorCode.MISSING_PARAMS,
+				context: { url: interpolateTemplateStringIfNeeded(cmd.url) },
 			}
 		}
 		if (cmd.paramsType && !(cmd.type in TimelineContentTypeHTTPParamType)) {
 			return {
 				result: ActionExecutionResultCode.Error,
 				response: t('Failed to send command: params type is invalid'),
+				code: HttpSendActionErrorCode.INVALID_PARAMS_TYPE,
+				context: { paramsType: cmd.paramsType },
 			}
 		}
 
@@ -220,9 +231,7 @@ export class HTTPSendDevice implements Device<HttpSendDeviceTypes, HttpSendDevic
 			}
 		}
 
-		this.context.logger.debug({ context, timelineObjId, command })
-
-		const t = Date.now()
+		const startTime = Date.now()
 
 		const httpReq = got[command.content.type]
 		try {
@@ -313,7 +322,7 @@ export class HTTPSendDevice implements Device<HttpSendDeviceTypes, HttpSendDevic
 				]
 
 				if (retryCodes.includes(err.code) && this.options?.resendTime && command.commandName !== 'manual') {
-					const timeLeft = Math.max(this.options.resendTime - (Date.now() - t), 0)
+					const timeLeft = Math.max(this.options.resendTime - (Date.now() - startTime), 0)
 					setTimeout(() => {
 						this.sendCommand({
 							timelineObjId,
@@ -329,6 +338,16 @@ export class HTTPSendDevice implements Device<HttpSendDeviceTypes, HttpSendDevic
 
 			return {
 				result: ActionExecutionResultCode.Error,
+				code: HttpSendActionErrorCode.REQUEST_FAILED,
+				context: {
+					url: interpolateTemplateStringIfNeeded(command.content.url),
+					errorMessage: err.message,
+					errorCode: 'code' in err ? String(err.code) : undefined,
+				},
+				response: t('HTTP request to {{url}} failed: {{errorMessage}}', {
+					url: interpolateTemplateStringIfNeeded(command.content.url),
+					errorMessage: err.message,
+				}),
 			}
 		}
 	}

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -114,7 +114,10 @@ export class HTTPSendDevice implements Device<HttpSendDeviceTypes, HttpSendDevic
 				context: { url: interpolateTemplateStringIfNeeded(cmd.url) },
 			}
 		}
-		if (cmd.paramsType && !(cmd.type in TimelineContentTypeHTTPParamType)) {
+		if (
+			cmd.paramsType &&
+			!Object.values<TimelineContentTypeHTTPParamType>(TimelineContentTypeHTTPParamType).includes(cmd.paramsType)
+		) {
 			return {
 				result: ActionExecutionResultCode.Error,
 				response: t('Failed to send command: params type is invalid'),


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of the BBC.

## Type of Contribution

This is a: Feature / Code improvement

## Current Behavior

<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

When a device action fails (e.g. CasparCG or HTTP Send), the `ActionExecutionResult` returned to the caller contains only a pre-rendered human-readable message. There is no structured way for consumers (e.g. blueprints) to identify the specific error type or to customise the error message for their context.

## New Behavior

<!--
What is the new behavior?
-->

`ActionExecutionResult` gains two optional fields:

- **`code`** — a structured error code following the pattern `ACTION_{DEVICETYPE}_{REASON}` (e.g. `ACTION_CASPARCG_LAUNCHER_HOST_NOT_SET`)
- **`context`** — a `Record<string, unknown>` providing values for custom message interpolation via `interpolateTemplateString()`

The `response` field continues to carry a pre-rendered fallback message, so existing consumers are unaffected. Consumers that want to customise messages can match on `code` and interpolate using `context`.

Both CasparCG and HTTP Send device integrations have been updated to return structured error codes and context on their action errors.

Additionally, the `ws` package has been bumped to address a vulnerability report (GHSA).

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
-->

- Trigger a failing CasparCG action (e.g. with no launcher host configured) and verify `ActionExecutionResult` includes a `code` and `context` alongside the existing `response` message.
- Trigger a failing HTTP Send action and verify the same.
- Verify that existing consumers that only use `response` continue to work unchanged.
- Run the unit tests: `yarn unit`

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

The `code`/`context` fields are purely additive and optional, making this change fully backwards-compatible. A blueprint can opt in to richer error messages by looking up `code` in a `deviceActionErrorMessages` map and interpolating with `context`.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
