### PR TITLE
fix(kairos): force dissolve properties on Scene Layers to be applied first, before other properties

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/kairos/commands.ts
+++ b/packages/timeline-state-resolver/src/integrations/kairos/commands.ts
@@ -149,7 +149,25 @@ export async function sendCommand(
 			}
 			break
 		case 'scene-layer': {
-			const values = { ...command.values }
+			const values: Partial<UpdateSceneLayerObject> = { ...command.values }
+			if (
+				values.dissolveEnabled !== undefined ||
+				values.dissolveTime !== undefined ||
+				values.dissolveMode !== undefined
+			) {
+				// Dissolve settings need to be applied first in order to be applied to the source change that may be specified in this command
+				const dissolveValues: Partial<UpdateSceneLayerObject> = {
+					dissolveEnabled: values.dissolveEnabled,
+					dissolveTime: values.dissolveTime,
+					dissolveMode: values.dissolveMode,
+				}
+
+				delete values.dissolveEnabled
+				delete values.dissolveTime
+				delete values.dissolveMode
+
+				await kairos.updateSceneLayer(command.ref, dissolveValues)
+			}
 			if (values.sourceA) {
 				// Handle loading ramrec/still into RAM if needed
 				const source = values.sourceA


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a:

<!-- (pick one) -->

Bug fix

## Current Behavior

Layer source transition (`dissolve_*`) properties on Scene Layers in Kairos are applied after properties such as `sourceA`, `sourcePgm` and `sourcePst`, meaning it's impossible to effect a source dissolve transition on a Scene Layer within a single timeline object.
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

## New Behavior

Layer source transition properties are applied before `source*` properties.
<!--
What is the new behavior?
-->

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

Check if source transitions on a Scene Layer in Kairos happen correctly in a single timeline object.

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
