### PR TITLE
feat(quick-tsr): Add ability to specify input folder

### DIFF
--- a/packages/quick-tsr/README.md
+++ b/packages/quick-tsr/README.md
@@ -7,7 +7,8 @@ An application for quick and easy testing of TSR.
 - Clone the repo
 - `yarn` to install
 - `cd packages/quick-tsr`
-- `yarn start` to start the application
+- `yarn start` to start with the default `input/` folder
+- `yarn start <folder>` to use a different input folder (relative to `packages/quick-tsr`, or absolute)
 
-- The application will monitor the contents in the folder `/input` and play them out.
-- Files and folders that begin with "\_" (underscore) will be ignored
+- The application monitors the chosen folder and plays out its timeline/mappings/devices.
+- Files and folders that begin with "_" (underscore) will be ignored

--- a/packages/quick-tsr/src/index.ts
+++ b/packages/quick-tsr/src/index.ts
@@ -12,7 +12,21 @@ console.log('Starting Quick-TSR')
 
 // const tsr = new TSRHandler(console.log)
 
-const watcher = chokidar.watch('input/**', { ignored: /^\./, persistent: true })
+/** Input folder relative to the package root (cwd). Defaults to `input`. */
+let inputDir = 'input'
+if (process.argv.length > 2) {
+	inputDir = path.resolve(process.argv[2])
+}
+
+if (!fs.existsSync(inputDir) || !fs.statSync(inputDir).isDirectory()) {
+	console.error(`Input folder does not exist or is not a directory: ${inputDir}`)
+	console.error(`Usage: yarn start [input-folder]`)
+	// eslint-disable-next-line n/no-process-exit -- exit on error
+	process.exit(1)
+}
+
+const inputDirPosix = inputDir.replaceAll('\\', '/')
+const watcher = chokidar.watch(`${inputDirPosix}/**`, { ignored: /^\./, persistent: true })
 
 watcher
 	.on('add', () => {
@@ -42,8 +56,9 @@ function reloadInput(changed?: { path: string; stats: fs.Stats }) {
 	const newInput: Input = pendingInput ?? structuredClone(currentInput)
 	pendingInput = newInput
 
-	_.each(getAllFilesInDirectory('input/'), (filePath) => {
-		const requirePath = '../' + filePath.replace(/\\/g, '/')
+	_.each(getAllFilesInDirectory(inputDir), (filePath) => {
+		// Absolute path so input folders outside this package (e.g. another repo) resolve correctly.
+		const requirePath = path.resolve(filePath)
 
 		if (requirePath.match(/[/\\]_/)) {
 			// ignore and folders files that begin with "_"
@@ -53,7 +68,9 @@ function reloadInput(changed?: { path: string; stats: fs.Stats }) {
 		if (filePath.match(/\.ts$/)) {
 			if (changed) {
 				// Only update if the file has updated:
-				if (changed.path !== filePath) {
+				const changedNorm = path.normalize(changed.path)
+				const fileNorm = path.normalize(filePath)
+				if (changedNorm !== fileNorm && path.resolve(changedNorm) !== path.resolve(fileNorm)) {
 					return
 				}
 			}
@@ -218,4 +235,4 @@ export interface TSRSettings {
 
 // ------------
 reloadInput()
-console.log('Listening to changes in /input...')
+console.log(`Listening to changes in ${inputDirPosix}...`)


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of SuperFly.tv.

## Type of Contribution

This is a Feature

## Current Behavior

<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

`quick-tsr` always watched the hard-coded `input/` folder. Testing a different device or timeline meant editing those example files in place (or carefully swapping them), which made it awkward to keep project-specific smoke tests outside this repo.

## New Behavior

<!--
What is the new behavior?
-->

`yarn start [folder]` accepts an optional input folder (relative to `packages/quick-tsr`, or absolute). The default remains `input/`. Files are loaded via absolute paths so folders outside the package resolve correctly, and `_`-prefixed path segments are still ignored.

Also removes a large commented-out keyframe block from the default CasparCG example timeline (no behaviour change).

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

1. `cd packages/quick-tsr`
2. `yarn start` — confirm it still loads the default `input/` CasparCG example and logs `Listening to changes in input...`
3. `yarn start /path/to/another/input-folder` — confirm it watches that folder instead and loads its devices/mappings/timeline
4. Pass a missing path and confirm it exits with a clear usage error

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

No production/runtime TSR behaviour change — `quick-tsr` only.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
